### PR TITLE
Convert unit tests for Collection, Set and MutableSet to parametrised tests.

### DIFF
--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -1,5 +1,6 @@
 package co.tsyba.core.collections;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -155,7 +156,13 @@ public interface Collection<T> extends Iterable<T> {
 	 * Returns items of this collection, ordered according to the specified
 	 * {@link Comparator}.
 	 */
-	List<T> sort(Comparator<T> comparator);
+	default List<T> sort(Comparator<T> comparator) {
+		final var items = toArray();
+		Arrays.sort(items, comparator);
+
+		final var store = new ContiguousArrayStore(items, items.length);
+		return new List<>(store);
+	}
 
 	/**
 	 * Applies the specified {@link Consumer} to every item of this collection.
@@ -223,7 +230,8 @@ public interface Collection<T> extends Iterable<T> {
 	/**
 	 * Returns items of this {@link Collection} in an array.
 	 */
-	default Object[] toArray() {
+	@SuppressWarnings("unchecked")
+	default T[] toArray() {
 		final var count = getCount();
 		final var items = new Object[count];
 		var index = 0;
@@ -233,7 +241,7 @@ public interface Collection<T> extends Iterable<T> {
 			++index;
 		}
 
-		return items;
+		return (T[]) items;
 	}
 }
 

--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -158,7 +158,8 @@ public interface Collection<T> extends Iterable<T> {
 	 * {@link Comparator}.
 	 */
 	default List<T> sort(Comparator<T> comparator) {
-		final var items = toArray();
+		@SuppressWarnings("unchecked")
+		final var items = (T[]) toArray();
 		Arrays.sort(items, comparator);
 
 		final var store = new ContiguousArrayStore(items, items.length);
@@ -166,10 +167,13 @@ public interface Collection<T> extends Iterable<T> {
 	}
 
 	/**
-	 * Returns items of this collection, ordered according to their natural order.
+	 * Returns items of this collection, ordered according to their natural order, when
+	 * items are {@link Comparable}; otherwise fails with {@link RuntimeException}.
+	 *
+	 * @throws RuntimeException when items of this collection are not {@link Comparable}.
 	 */
-	@SuppressWarnings("unchecked")
 	default List<T> sort() {
+		@SuppressWarnings("unchecked")
 		final var comparator = (Comparator<T>) Comparator.naturalOrder();
 		return sort(comparator);
 	}
@@ -289,10 +293,9 @@ public interface Collection<T> extends Iterable<T> {
 	/**
 	 * Returns items of this {@link Collection} in an array.
 	 */
-	@SuppressWarnings("unchecked")
-	default T[] toArray() {
+	default Object[] toArray() {
 		final var count = getCount();
-		final var items = (T[]) new Object[count];
+		final var items = new Object[count];
 		var index = 0;
 
 		for (var item : this) {
@@ -300,12 +303,10 @@ public interface Collection<T> extends Iterable<T> {
 			++index;
 		}
 
-		return copy(items);
+		return items;
 	}
 
-	private static <T> T[] copy(T... items) {
-		return Arrays.copyOf(items, items.length);
-	}
+
 }
 
 // created on May 12, 2019

--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -8,11 +8,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 /**
- * A container, which allows iteration over its items.
+ * A container, which allows non-destructive iteration over its items.
  * <p>
- * Unlike more general {@link Iterable}, {@link Collection} guarantees iteration will not
- * destructively consume it. Therefore, it can be iterated any number of times. This
- * requirement enables useful operations, which can be based solely on iterability.
+ * Unlike more general {@link Iterable}, {@link Collection} requires that iteration does
+ * not destructively consume it. And so, it can be iterated any number of times.
  * <p>
  * Note, that {@link Collection} does not guarantee that relative item order stays the
  * same in each iteration.

--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -291,7 +291,7 @@ public interface Collection<T> extends Iterable<T> {
 	}
 
 	/**
-	 * Returns items of this {@link Collection} in an array.
+	 * Returns items of this collection in an array.
 	 */
 	default Object[] toArray() {
 		final var count = getCount();
@@ -306,7 +306,21 @@ public interface Collection<T> extends Iterable<T> {
 		return items;
 	}
 
+	/**
+	 * Returns items of this collection in a typed array.
+	 */
+	default T[] toArray(Class<? extends T[]> klass) {
+		final var count = getCount();
+		final var items = Arrays.copyOf(new Object[0], count, klass);
 
+		var index = 0;
+		for (var item : this) {
+			items[index] = item;
+			++index;
+		}
+
+		return items;
+	}
 }
 
 // created on May 12, 2019

--- a/src/main/java/co/tsyba/core/collections/ContiguousArrayStore.java
+++ b/src/main/java/co/tsyba/core/collections/ContiguousArrayStore.java
@@ -1,7 +1,6 @@
 package co.tsyba.core.collections;
 
 import java.util.Arrays;
-import java.util.Random;
 
 import static java.lang.System.arraycopy;
 import static java.util.Arrays.fill;
@@ -232,38 +231,6 @@ class ContiguousArrayStore {
 		}
 
 		return new ContiguousArrayStore(reversed, itemCount);
-	}
-
-	/**
-	 * Returns items of this store in random order, based on the specified
-	 * {@link Random}.
-	 *
-	 * <pre>
-	 * Implements in-place version of Fisher-Yates shuffle algorithm.
-	 *
-	 * Sources:
-	 * 1. R. Durstenfeld. "Algorithm 235: Random permutation".
-	 *    Communications of the ACM, vol. 7, July 1964, p. 420.
-	 * 2. D. Knuth. "The Art of Computer Programming" vol. 2.
-	 *    Addison–Wesley, 1969, pp. 139–140, algorithm P.
-	 * </pre>
-	 */
-	ContiguousArrayStore shuffle(Random random) {
-		final var shuffled = new Object[items.length];
-		arraycopy(items, 0, shuffled, 0, itemCount);
-
-		// it's more convenient to iterate items backwards for simpler
-		// random index generation
-		for (var index = itemCount - 1; index >= 0; --index) {
-			final var randomIndex = random.nextInt(index + 1);
-
-			// swap items at iterated and randomly generated indices
-			final var item = shuffled[index];
-			shuffled[index] = shuffled[randomIndex];
-			shuffled[randomIndex] = item;
-		}
-
-		return new ContiguousArrayStore(shuffled, itemCount);
 	}
 
 	void ensureExcessCapacity(int extra) {

--- a/src/main/java/co/tsyba/core/collections/ContiguousArrayStore.java
+++ b/src/main/java/co/tsyba/core/collections/ContiguousArrayStore.java
@@ -1,7 +1,6 @@
 package co.tsyba.core.collections;
 
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.Random;
 
 import static java.lang.System.arraycopy;
@@ -48,7 +47,7 @@ class ContiguousArrayStore {
 		this.itemCount = 0;
 	}
 
-	private ContiguousArrayStore(Object[] items, int itemCount) {
+	ContiguousArrayStore(Object[] items, int itemCount) {
 		this.items = items;
 		this.itemCount = itemCount;
 	}
@@ -233,19 +232,6 @@ class ContiguousArrayStore {
 		}
 
 		return new ContiguousArrayStore(reversed, itemCount);
-	}
-
-	/**
-	 * Returns items of this store, ordered according to the specified
-	 * {@link Comparator}.
-	 */
-	@SuppressWarnings("unchecked")
-	<T> ContiguousArrayStore sort(Comparator<T> comparator) {
-		final var sorted = new Object[items.length];
-		arraycopy(items, 0, sorted, 0, itemCount);
-
-		Arrays.sort((T[]) sorted, 0, itemCount, comparator);
-		return new ContiguousArrayStore(sorted, itemCount);
 	}
 
 	/**

--- a/src/main/java/co/tsyba/core/collections/List.java
+++ b/src/main/java/co/tsyba/core/collections/List.java
@@ -432,9 +432,8 @@ public class List<T> implements Collection<T> {
 	}
 
 	@Override
-	@SuppressWarnings("unchecked")
-	public T[] toArray() {
-		return (T[]) Arrays.copyOf(store.items, store.itemCount);
+	public Object[] toArray() {
+		return Arrays.copyOf(store.items, store.itemCount);
 	}
 
 	@Override

--- a/src/main/java/co/tsyba/core/collections/List.java
+++ b/src/main/java/co/tsyba/core/collections/List.java
@@ -3,7 +3,6 @@ package co.tsyba.core.collections;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Optional;
-import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -347,17 +346,6 @@ public class List<T> implements Collection<T> {
 	public List<T> reverse() {
 		final var reversed = store.reverse();
 		return new List<>(reversed);
-	}
-
-	/**
-	 * Returns items of this list in random order.
-	 */
-	public List<T> shuffle() {
-		final var time = System.currentTimeMillis();
-		final var random = new Random(time);
-		final var shuffled = store.shuffle(random);
-
-		return new List<>(shuffled);
 	}
 
 	@Override

--- a/src/main/java/co/tsyba/core/collections/List.java
+++ b/src/main/java/co/tsyba/core/collections/List.java
@@ -1,6 +1,9 @@
 package co.tsyba.core.collections;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Random;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -346,12 +349,6 @@ public class List<T> implements Collection<T> {
 		return new List<>(reversed);
 	}
 
-	@Override
-	public List<T> sort(Comparator<T> comparator) {
-		final var sorted = store.sort(comparator);
-		return new List<>(sorted);
-	}
-
 	/**
 	 * Returns items of this list in random order.
 	 */
@@ -447,8 +444,9 @@ public class List<T> implements Collection<T> {
 	}
 
 	@Override
-	public Object[] toArray() {
-		return Arrays.copyOf(store.items, store.itemCount);
+	@SuppressWarnings("unchecked")
+	public T[] toArray() {
+		return (T[]) Arrays.copyOf(store.items, store.itemCount);
 	}
 
 	@Override

--- a/src/main/java/co/tsyba/core/collections/MutableList.java
+++ b/src/main/java/co/tsyba/core/collections/MutableList.java
@@ -346,8 +346,8 @@ public class MutableList<T> extends List<T> {
 
 	@Override
 	public MutableList<T> sort(Comparator<T> comparator) {
-		final var sorted = store.sort(comparator);
-		return new MutableList<>(sorted);
+		final var sorted = super.sort(comparator);
+		return new MutableList<>(sorted.store);
 	}
 
 	@Override

--- a/src/main/java/co/tsyba/core/collections/MutableList.java
+++ b/src/main/java/co/tsyba/core/collections/MutableList.java
@@ -351,12 +351,21 @@ public class MutableList<T> extends List<T> {
 	}
 
 	@Override
-	public MutableList<T> shuffle() {
-		final var seed = System.currentTimeMillis();
-		final var random = new Random(seed);
-		final var shuffled = store.shuffle(random);
+	public List<T> sort() {
+		final var sorted = super.sort();
+		return new MutableList<>(sorted.store);
+	}
 
-		return new MutableList<>(shuffled);
+	@Override
+	public MutableList<T> shuffle(Random random) {
+		final var shuffled = super.shuffle(random);
+		return new MutableList<>(shuffled.store);
+	}
+
+	@Override
+	public List<T> shuffle() {
+		final var shuffled = super.shuffle();
+		return new MutableList<>(shuffled.store);
 	}
 
 	@Override

--- a/src/main/java/co/tsyba/core/collections/MutableMap.java
+++ b/src/main/java/co/tsyba/core/collections/MutableMap.java
@@ -3,8 +3,8 @@ package co.tsyba.core.collections;
 public class MutableMap<K, V> extends Map<K, V> {
 	private static final int minimumCapacity = 64;
 
-	MutableMap(RobinHoodHashStore<Entry<K, V>> store) {
-		super(store);
+	MutableMap(Set<Entry<K, V>> store) {
+		super(store.store);
 	}
 
 	/**

--- a/src/main/java/co/tsyba/core/collections/MutableSet.java
+++ b/src/main/java/co/tsyba/core/collections/MutableSet.java
@@ -86,7 +86,9 @@ public class MutableSet<T> extends Set<T> {
 	}
 
 	/**
-	 * Removes the specified items from this set, if present. Returns itself.
+	 * Removes any of the specified items present in this set. Returns itself.
+	 * <p>
+	 * Ignores any {@code null} values among the specified items.
 	 */
 	@SafeVarargs
 	public final MutableSet<T> remove(T... items) {
@@ -100,7 +102,7 @@ public class MutableSet<T> extends Set<T> {
 	}
 
 	/**
-	 * Removes the specified items from this set, if present. Returns itself.
+	 * Removes any of the specified items present in this set. Returns itself.
 	 */
 	public MutableSet<T> remove(Collection<T> items) {
 		for (var item : items) {
@@ -112,6 +114,8 @@ public class MutableSet<T> extends Set<T> {
 
 	/**
 	 * Removes the specified items from this set, if present. Returns itself.
+	 * <p>
+	 * Ignores any {@code null} values among the specified items.
 	 */
 	public MutableSet<T> remove(Iterable<T> items) {
 		for (var item : items) {

--- a/src/main/java/co/tsyba/core/collections/MutableSet.java
+++ b/src/main/java/co/tsyba/core/collections/MutableSet.java
@@ -1,5 +1,9 @@
 package co.tsyba.core.collections;
 
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
 /**
  * A mutable, unordered {@link Collection} of unique items.
  */
@@ -17,6 +21,36 @@ public class MutableSet<T> extends Set<T> {
 		super(items);
 	}
 
+	@Override
+	public MutableSet<T> unite(Set<T> set) {
+		final var items = super.unite(set);
+		return new MutableSet<>(items.store);
+	}
+
+	@Override
+	public MutableSet<T> intersect(Set<T> set) {
+		final var items = super.intersect(set);
+		return new MutableSet<>(items.store);
+	}
+
+	@Override
+	public MutableSet<T> subtract(Set<T> set) {
+		final var items = super.subtract(set);
+		return new MutableSet<>(items.store);
+	}
+
+	@Override
+	public MutableSet<T> symmetricSubtract(Set<T> set) {
+		final var items = super.symmetricSubtract(set);
+		return new MutableSet<>(items.store);
+	}
+
+	@Override
+	public <R> MutableSet<Pair<T, R>> multiply(Set<R> set) {
+		final var items = super.multiply(set);
+		return new MutableSet<>(items.store);
+	}
+
 	/**
 	 * Adds the specified item to this set. Returns itself.
 	 * <p>
@@ -24,7 +58,7 @@ public class MutableSet<T> extends Set<T> {
 	 */
 	public MutableSet<T> add(T item) {
 		if (item != null) {
-			insert(item);
+			store.insert(item);
 		}
 
 		return this;
@@ -39,7 +73,7 @@ public class MutableSet<T> extends Set<T> {
 	public final MutableSet<T> add(T... items) {
 		for (var item : items) {
 			if (item != null) {
-				insert(item);
+				store.insert(item);
 			}
 		}
 
@@ -51,7 +85,7 @@ public class MutableSet<T> extends Set<T> {
 	 */
 	public MutableSet<T> add(Collection<T> items) {
 		for (var item : items) {
-			insert(item);
+			store.insert(item);
 		}
 
 		return this;
@@ -65,7 +99,7 @@ public class MutableSet<T> extends Set<T> {
 	public MutableSet<T> add(Iterable<T> items) {
 		for (var item : items) {
 			if (item != null) {
-				insert(item);
+				store.insert(item);
 			}
 		}
 
@@ -79,7 +113,7 @@ public class MutableSet<T> extends Set<T> {
 	 */
 	public MutableSet<T> remove(T item) {
 		if (item != null) {
-			delete(item);
+			store.delete(item);
 		}
 
 		return this;
@@ -94,7 +128,7 @@ public class MutableSet<T> extends Set<T> {
 	public final MutableSet<T> remove(T... items) {
 		for (var item : items) {
 			if (item != null) {
-				delete(item);
+				store.delete(item);
 			}
 		}
 
@@ -106,7 +140,7 @@ public class MutableSet<T> extends Set<T> {
 	 */
 	public MutableSet<T> remove(Collection<T> items) {
 		for (var item : items) {
-			delete(item);
+			store.delete(item);
 		}
 
 		return this;
@@ -120,7 +154,7 @@ public class MutableSet<T> extends Set<T> {
 	public MutableSet<T> remove(Iterable<T> items) {
 		for (var item : items) {
 			if (item != null) {
-				delete(item);
+				store.delete(item);
 			}
 		}
 
@@ -131,8 +165,25 @@ public class MutableSet<T> extends Set<T> {
 	 * Removes all items from this set. Returns itself.
 	 */
 	public MutableSet<T> removeAll() {
-		deleteAll();
+		store.deleteAll();
 		return this;
+	}
+
+	@Override
+	public MutableSet<T> iterate(Consumer<T> operation) {
+		return (MutableSet<T>) super.iterate(operation);
+	}
+
+	@Override
+	public MutableSet<T> filter(Predicate<T> condition) {
+		final var items = super.filter(condition);
+		return new MutableSet<>(items.store);
+	}
+
+	@Override
+	public <R> MutableSet<R> convert(Function<T, R> converter) {
+		final var items = super.convert(converter);
+		return new MutableSet<>(items.store);
 	}
 
 	/**

--- a/src/main/java/co/tsyba/core/collections/Set.java
+++ b/src/main/java/co/tsyba/core/collections/Set.java
@@ -1,7 +1,5 @@
 package co.tsyba.core.collections;
 
-import java.util.Arrays;
-import java.util.Comparator;
 import java.util.HashSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -205,21 +203,6 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 
 		product.removeExcessCapacity();
 		return product;
-	}
-
-	@Override
-	public List<T> sort(Comparator<T> comparator) {
-		@SuppressWarnings("unchecked")
-		final var items = (T[]) new Object[entryCount];
-		var index = 0;
-
-		for (var item : this) {
-			items[index] = item;
-			++index;
-		}
-
-		Arrays.sort(items, comparator);
-		return new List<>(items);
 	}
 
 	@Override

--- a/src/main/java/co/tsyba/core/collections/Set.java
+++ b/src/main/java/co/tsyba/core/collections/Set.java
@@ -63,6 +63,10 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 
 	@Override
 	public boolean contains(T item) {
+		if (item == null) {
+			return false;
+		}
+
 		final var index = find(item);
 		return index > -1;
 	}

--- a/src/main/java/co/tsyba/core/collections/Set.java
+++ b/src/main/java/co/tsyba/core/collections/Set.java
@@ -73,11 +73,10 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 	 * Returns {@code true} when this set is disjoint from the specified one; returns
 	 * {@code false} otherwise.
 	 * <p>
-	 * This set is disjoint from the specified one (or vice versa) when they don't have
-	 * any common items.
+	 * Two sets are disjoint when they don't contain any common items.
 	 * <p>
-	 * When this or the specified set is empty, this method returns {@code false}, since
-	 * an empty set is disjoint from all other sets, including itself.
+	 * When this or the specified set is empty, returns {@code false}, since an empty set
+	 * is disjoint from all other sets, including itself.
 	 */
 	public boolean isDisjoint(Set<T> set) {
 		return noneMatches(set::contains);
@@ -86,7 +85,7 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 	/**
 	 * Returns union (A∪B) of this set and the specified one.
 	 * <p>
-	 * The returned set contains all items from this and the specified sets.
+	 * A union of two sets contains all (distinct) items from both sets.
 	 */
 	public Set<T> unite(Set<T> set) {
 		final var capacity = getCount() + set.getCount();
@@ -107,8 +106,7 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 	 * Returns {@code true} when this set intersects the specified one; returns
 	 * {@code false} otherwise.
 	 * <p>
-	 * This set intersects the specified one (or vice versa) when they have some common
-	 * items.
+	 * A set intersects another set when they have at least one common item.
 	 * <p>
 	 * When this or the specified set is empty, returns {@code false}, since an empty set
 	 * never intersects another set, including itself.
@@ -120,8 +118,7 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 	/**
 	 * Returns intersection (A∩B) of this set and the specified one.
 	 * <p>
-	 * The returned set contains items, which are only present in both this and the
-	 * specified sets.
+	 * An intersection of two sets contains all of their common items.
 	 */
 	public Set<T> intersect(Set<T> set) {
 		final var capacity = getCount() + set.getCount();
@@ -140,8 +137,8 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 	/**
 	 * Returns difference (A\B) of this set from the specified one.
 	 * <p>
-	 * The returned set contains items from this set, which are not present in the
-	 * specified one.
+	 * A difference of a set from another set contains all items from the first set,
+	 * except those, which are common with the other set.
 	 */
 	public Set<T> subtract(Set<T> set) {
 		final var capacity = getCount() + set.getCount();
@@ -161,9 +158,8 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 	 * Returns symmetric difference (AΔB = (A\B)∪(B\A)) between this set and the specified
 	 * one.
 	 * <p>
-	 * The returned set contains items from this set, which are not present in the
-	 * specified one, plus items, which are present in the specified set, but not this
-	 * one.
+	 * A symmetric difference of a set with another set contains all (distinct) items from
+	 * both sets, except those, which are common between them.
 	 */
 	public Set<T> symmetricSubtract(Set<T> set) {
 		final var capacity = getCount() + set.getCount();
@@ -187,8 +183,8 @@ public class Set<T> extends RobinHoodHashStore<T> implements Collection<T> {
 	/**
 	 * Returns cartesian product (A×B) of this set and the specified one.
 	 * <p>
-	 * The returned set contains all ordered pairs, where first item of a pair is from
-	 * this set, and the second one is from the specified set.
+	 * A cartesian product contains all possible (distinct) pairs of items from both
+	 * sets.
 	 */
 	public <R> Set<Pair<T, R>> multiply(Set<R> set) {
 		final var capacity = getCount() * set.getCount();

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -1,5 +1,6 @@
 package co.tsyba.core.collections;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
@@ -242,6 +243,23 @@ public class CollectionTests {
 		assertEquals(expected, anyMatches);
 	}
 
+	@DisplayName(".sort(Comparator<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, returns sorted list;" +
+			"[k, M, s, A, 8, d, q];" +
+			"[8, A, M, d, k, q, s]",
+		"when collection is empty, returns empty list;" +
+			"[];" +
+			"[]"
+	})
+	void testSort(String name, @StringCollection Collection<String> items,
+		@StringList List<String> expected) {
+
+		final var sorted = items.sort(Comparator.naturalOrder());
+		Assertions.assertEquals(expected, sorted);
+	}
+
 	@DisplayName(".iterate(Consumer<T>)")
 	@ParameterizedTest(name = "{0}")
 	@CsvSource(delimiter = ';', value = {
@@ -392,11 +410,6 @@ abstract class AbstractArrayCollection<T> implements Collection<T> {
 	@SafeVarargs
 	protected AbstractArrayCollection(T... items) {
 		this.items = items;
-	}
-
-	@Override
-	public List<T> sort(Comparator<T> comparator) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -21,14 +21,14 @@ import static org.junit.jupiter.api.Assertions.*;
 public class CollectionTests {
 	@DisplayName(".isEmpty()")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, returns false;" +
 			"[f, T, q, r];" +
 			"false",
 		"when collection is empty, returns true;" +
 			"[];" +
 			"true"
-	})
+	}, delimiter = ';')
 	void testIsEmpty(String name, @StringCollection Collection<String> items,
 		boolean expected) {
 
@@ -38,14 +38,14 @@ public class CollectionTests {
 
 	@DisplayName(".getCount()")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, returns item count;" +
 			"[b, 5, F, e];" +
 			"4",
 		"when collection is empty, returns 0;" +
 			"[];" +
 			"0"
-	})
+	}, delimiter = ';')
 	void testGetCount(String name, @StringCollection Collection<String> items,
 		int expected) {
 
@@ -55,14 +55,14 @@ public class CollectionTests {
 
 	@DisplayName(".getMinimum(Comparator<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, returns minimum;" +
 			"[b, L, P, g, V, c];" +
 			"L",
 		"when collection is empty, returns empty optional;" +
 			"[];" +
-			" "
-	})
+			"null"
+	}, delimiter = ';', nullValues = "null")
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	void testGetMinimum(String name, @StringCollection Collection<String> items,
 		@StringOptional Optional<String> expected) {
@@ -73,14 +73,14 @@ public class CollectionTests {
 
 	@DisplayName(".getMaximum(Comparator<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, returns maximum;" +
 			"[b, L, P, g, V, c];" +
 			"g",
 		"when collection is empty, returns empty optional;" +
 			"[];" +
-			" "
-	})
+			"null"
+	}, delimiter = ';', nullValues = "null")
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	void testGetMaximum(String name, @StringCollection Collection<String> items,
 		@StringOptional Optional<String> expected) {
@@ -91,7 +91,7 @@ public class CollectionTests {
 
 	@DisplayName(".contains(T)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when item is present, returns true;" +
 			"[t, d, 5, V, A]; 5;" +
 			"true",
@@ -101,7 +101,7 @@ public class CollectionTests {
 		"when collection is empty, returns false;" +
 			"[]; 5;" +
 			"false",
-	})
+	}, delimiter = ';')
 	void testContains(String name, @StringCollection Collection<String> items,
 		String item, boolean expected) {
 
@@ -111,7 +111,7 @@ public class CollectionTests {
 
 	@DisplayName(".contains(Collection<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when all items are present, returns true;" +
 			"[t, d, 5, V, A]; [A, d, t];" +
 			"true",
@@ -130,7 +130,7 @@ public class CollectionTests {
 		"when collection and items are empty, returns true;" +
 			"[]; [];" +
 			"true"
-	})
+	}, delimiter = ';')
 	void testContainsCollection(String name, @StringCollection Collection<String> items1,
 		@StringCollection Collection<String> items2, boolean expected) {
 
@@ -140,7 +140,7 @@ public class CollectionTests {
 
 	@DisplayName(".match(Predicate<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when some item matches, returns matched item;" +
 			"[F, V, d, P, a, Q];" +
 			"d",
@@ -149,8 +149,8 @@ public class CollectionTests {
 			" ",
 		"when collection is empty, returns empty optional;" +
 			"[];" +
-			" "
-	})
+			"null"
+	}, delimiter = ';', nullValues = "null")
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 	void testMatch(String name, @StringCollection Collection<String> items,
 		@StringOptional Optional<String> expected) {
@@ -165,7 +165,7 @@ public class CollectionTests {
 
 	@DisplayName(".noneMatches(Predicate<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when no item matches, returns true;" +
 			"[K, M, T, S, A];" +
 			"true",
@@ -178,7 +178,7 @@ public class CollectionTests {
 		"when collection is empty, returns true;" +
 			"[];" +
 			"true",
-	})
+	}, delimiter = ';')
 	void testNoneMatches(String name, @StringCollection Collection<String> items,
 		boolean expected) {
 
@@ -192,7 +192,7 @@ public class CollectionTests {
 
 	@DisplayName(".anyMatches(Predicate<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when no item matches, returns false;" +
 			"[Y, P, D, A, S, M, S];" +
 			"false",
@@ -205,7 +205,7 @@ public class CollectionTests {
 		"when collection is empty, returns false;" +
 			"[];" +
 			"false",
-	})
+	}, delimiter = ';')
 	void testAnyMatches(String name, @StringCollection Collection<String> items,
 		boolean expected) {
 
@@ -219,7 +219,7 @@ public class CollectionTests {
 
 	@DisplayName(".eachMatches(Predicate<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when no item matches, returns false;" +
 			"[H, B, S, A];" +
 			"false",
@@ -232,7 +232,7 @@ public class CollectionTests {
 		"when collection is empty, returns true;" +
 			"[];" +
 			"true",
-	})
+	}, delimiter = ';')
 	void testEachMatches(String name, @StringCollection Collection<String> items,
 		boolean expected) {
 
@@ -246,14 +246,14 @@ public class CollectionTests {
 
 	@DisplayName(".sort(Comparator<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, returns sorted list;" +
 			"[k, M, s, A, 8, d, q];" +
 			"[s, q, k, d, M, A, 8]",
 		"when collection is empty, returns empty list;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testSortComparator(String name, @StringCollection Collection<String> items,
 		@StringList List<String> expected) {
 
@@ -263,14 +263,14 @@ public class CollectionTests {
 
 	@DisplayName(".sort()")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, returns sorted list;" +
 			"[k, M, s, A, 8, d, q];" +
 			"[8, A, M, d, k, q, s]",
 		"when collection is empty, returns empty list;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testSort(String name, @StringCollection Collection<String> items,
 		@StringList List<String> expected) {
 
@@ -278,19 +278,17 @@ public class CollectionTests {
 		Assertions.assertEquals(expected, sorted);
 	}
 
-	@DisplayName(".<T not Comparable>sort()")
+	@DisplayName(".sort(), where T not Comparable")
 	@Test
 	void testSortNotComparable() {
-		Assertions.assertThrows(RuntimeException.class,
-			() -> {
-				final var collection = new AbstractPredicateCollection<>(
-					String::isEmpty,
-					String::isBlank
-				) {
-				};
-
-				collection.sort();
-			});
+		Assertions.assertThrows(RuntimeException.class, () -> {
+			final var collection = new AbstractPredicateCollection<>(
+				String::isEmpty,
+				String::isBlank
+			) {
+			};
+			collection.sort();
+		});
 	}
 
 	@DisplayName(".shuffle(Random)")
@@ -362,14 +360,14 @@ public class CollectionTests {
 
 	@DisplayName(".iterate(Consumer<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, iterates items;" +
 			"[f, F, e, q, p, L];" +
 			"[f, F, e, q, p, L]",
 		"when collection is empty, does nothing;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testIterate(String name, @StringCollection Collection<String> items,
 		@StringArray String[] expected) {
 
@@ -383,14 +381,14 @@ public class CollectionTests {
 
 	@DisplayName(".combine(R, BiFunction<R, T, R>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, combines items with initial value;" +
 			"[g, E, Q, s, a, B]; B;" +
 			"BgEQsaB",
 		"when collection is empty, returns initial value;" +
 			"[]; A;" +
 			"A"
-	})
+	}, delimiter = ';')
 	void testCombine(String name, @StringCollection Collection<String> items,
 		String initial, String expected) {
 
@@ -403,14 +401,14 @@ public class CollectionTests {
 
 	@DisplayName(".join(String)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, joins items into a string;" +
 			"[g, t, W, q, P, l]; -;" +
 			"g-t-W-q-P-l",
 		"when collection is empty, returns empty string;" +
 			"[]; -;" +
-			" "
-	})
+			"null"
+	}, delimiter = ';', nullValues = "null")
 	void testJoin(String name, @StringCollection Collection<String> items,
 		String separator, String expected) {
 
@@ -424,14 +422,14 @@ public class CollectionTests {
 
 	@DisplayName(".toArray()")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, returns items array;" +
 			"[T, b, 4, 0, O];" +
 			"[T, b, 4, 0, O]",
 		"when collection is empty, returns empty array;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testToArray(String name, @StringCollection Collection<String> items,
 		@StringArray String[] expected) {
 
@@ -441,14 +439,14 @@ public class CollectionTests {
 
 	@DisplayName(".toArray(Class<? extends T[]>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when collection is not empty, returns items array;" +
 			"[V, b, Q, r, 4, p];" +
 			"[V, b, Q, r, 4, p]",
 		"when collection is empty, returns empty array;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testToArrayClass(String name, @StringCollection Collection<String> items,
 		@StringArray String[] expected) {
 
@@ -510,8 +508,7 @@ public class CollectionTests {
 
 		@Override
 		protected Optional<String> convert(String s) throws ArgumentConversionException {
-			return Optional.ofNullable(s)
-				.filter((s2) -> !s2.equals("null"));
+			return Optional.ofNullable(s);
 		}
 	}
 }

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -439,11 +439,27 @@ public class CollectionTests {
 		assertArrayEquals(expected, array);
 	}
 
+	@DisplayName(".toArray(Class<? extends T[]>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, returns items array;" +
+			"[V, b, Q, r, 4, p];" +
+			"[V, b, Q, r, 4, p]",
+		"when collection is empty, returns empty array;" +
+			"[];" +
+			"[]"
+	})
+	void testToArrayClass(String name, @StringCollection Collection<String> items,
+		@StringArray String[] expected) {
+
+		final var array = items.toArray(String[].class);
+		assertArrayEquals(expected, array);
+	}
+
 	static void assertShuffled
 		(Collection<String> shuffled, Collection<String> unshuffled) {
-		// todo: change to var once cast in .toArray() is resolved
-		final Object[] items1 = shuffled.toArray();
-		final Object[] items2 = unshuffled.toArray();
+		final var items1 = shuffled.toArray(String[].class);
+		final var items2 = unshuffled.toArray(String[].class);
 		assertArrayNotEquals(items1, items2);
 
 		Arrays.sort(items1);

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -1,467 +1,432 @@
 package co.tsyba.core.collections;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.converter.TypedArgumentConverter;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 public class CollectionTests {
-	@Nested
 	@DisplayName(".isEmpty()")
-	class IsEmptyTests {
-		@Test
-		@DisplayName("returns true when collection is empty")
-		void returnsTrueWhenEmpty() {
-			final var items = new TestCollection<>();
-			assert items.isEmpty();
-		}
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, returns false;" +
+			"[f, T, q, r];" +
+			"false",
+		"when collection is empty, returns true;" +
+			"[];" +
+			"true"
+	})
+	void testIsEmpty(String name, @StringCollection Collection<String> items,
+		boolean expected) {
 
-		@Test
-		@DisplayName("returns false when collection is not empty")
-		void returnsFalseWhenNotEmpty() {
-			final var items = new TestCollection<>("f", "T", "q", "r");
-			assert !items.isEmpty();
-		}
+		final var empty = items.isEmpty();
+		assertEquals(expected, empty);
 	}
 
-	@Nested
 	@DisplayName(".getCount()")
-	class GetCountTests {
-		@Test
-		@DisplayName("returns item count when collection is not empty")
-		void returnsCountWhenNotEmpty() {
-			final var items = new TestCollection<>("b", "5", "F", "e");
-			final var count = items.getCount();
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, returns item count;" +
+			"[b, 5, F, e];" +
+			"4",
+		"when collection is empty, returns 0;" +
+			"[];" +
+			"0"
+	})
+	void testGetCount(String name, @StringCollection Collection<String> items,
+		int expected) {
 
-			assert 4 == count;
-		}
-
-		@Test
-		@DisplayName("returns 0 when collection is empty")
-		void returnsZeroWhenEmpty() {
-			final var items = new TestCollection<>();
-			final var count = items.getCount();
-
-			assert 0 == count;
-		}
+		final var count = items.getCount();
+		assertEquals(expected, count);
 	}
 
-	@Nested
-	@DisplayName(".getMinimum()")
-	class GetMinimumTests {
-		@Test
-		@DisplayName("returns minimum item when collection is not empty")
-		void returnsMinWhenNotEmpty() {
-			final var items = new TestCollection<>(5, 12, 7, 0, 3, 6);
-			final var minimum = items.getMinimum(Comparator.naturalOrder());
+	@DisplayName(".getMinimum(Comparator<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, returns minimum;" +
+			"[b, L, P, g, V, c];" +
+			"L",
+		"when collection is empty, returns empty optional;" +
+			"[];" +
+			" "
+	})
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	void testGetMinimum(String name, @StringCollection Collection<String> items,
+		@StringOptional Optional<String> expected) {
 
-			assert Optional.of(0)
-				.equals(minimum);
-		}
-
-		@Test
-		@DisplayName("returns empty when collection is empty")
-		void returnsEmptyWhenEmpty() {
-			final var items = new TestCollection<Integer>();
-			final var minimum = items.getMinimum(Comparator.naturalOrder());
-
-			assert minimum.isEmpty();
-		}
+		final var min = items.getMinimum(Comparator.naturalOrder());
+		assertEquals(expected, min);
 	}
 
-	@Nested
-	@DisplayName(".getMaximum()")
-	class GetMaximumTests {
-		@Test
-		@DisplayName("returns maximum item when collection is not empty")
-		void returnsMaxWhenNotEmpty() {
-			final var items = new TestCollection<>(5, 12, 7, 0, 3, 6);
-			final var maximum = items.getMaximum(Comparator.naturalOrder());
+	@DisplayName(".getMaximum(Comparator<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, returns maximum;" +
+			"[b, L, P, g, V, c];" +
+			"g",
+		"when collection is empty, returns empty optional;" +
+			"[];" +
+			" "
+	})
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	void testGetMaximum(String name, @StringCollection Collection<String> items,
+		@StringOptional Optional<String> expected) {
 
-			assert Optional.of(12)
-				.equals(maximum);
-		}
-
-		@Test
-		@DisplayName("returns empty when collection is empty")
-		void returnsEmptyWhenEmpty() {
-			final var items = new TestCollection<Integer>();
-			final var maximum = items.getMaximum(Comparator.naturalOrder());
-
-			assert maximum.isEmpty();
-		}
+		final var min = items.getMaximum(Comparator.naturalOrder());
+		assertEquals(expected, min);
 	}
 
-	@Nested
 	@DisplayName(".contains(T)")
-	class ContainsTests {
-		@Test
-		@DisplayName("returns true when item is present")
-		void returnsTrueWhenPresent() {
-			final var items = new TestCollection<>("t", "d", "5", "V", "A");
-			assert items.contains("5");
-		}
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when item is present, returns true;" +
+			"[t, d, 5, V, A]; 5;" +
+			"true",
+		"when item is absent, returns false;" +
+			"[t, d, 5, V, A]; 7;" +
+			"false",
+		"when collection is empty, returns false;" +
+			"[]; 5;" +
+			"false",
+	})
+	void testContains(String name, @StringCollection Collection<String> items,
+		String item, boolean expected) {
 
-		@Test
-		@DisplayName("returns false when item is absent")
-		void returnsFalseWhenAbsent() {
-			final var items = new TestCollection<>("O", "P", "q");
-			assert !items.contains("5");
-		}
-
-		@Test
-		@DisplayName("returns false when collection is empty")
-		void returnsFalseWhenEmpty() {
-			final var items = new TestCollection<>();
-			assert !items.contains("5");
-		}
+		final var contains = items.contains(item);
+		assertEquals(expected, contains);
 	}
 
-	@Nested
 	@DisplayName(".contains(Collection<T>)")
-	class ContainsCollectionTests {
-		@Test
-		@DisplayName("returns true when all items are present")
-		void returnsTrueWhenAllPresent() {
-			final var items1 = new TestCollection<>("t", "d", "5", "V", "A");
-			final var items2 = new TestCollection<>("A", "d", "t");
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when all items are present, returns true;" +
+			"[t, d, 5, V, A]; [A, d, t];" +
+			"true",
+		"when some items are absent, returns false;" +
+			"[O, P, q]; [P, 0, O];" +
+			"false",
+		"when all items are absent, returns false;" +
+			"[Y, f, E, 3]; [N, R, P];" +
+			"false",
+		"when items are empty, returns true;" +
+			"[Y, f, E, 3]; [];" +
+			"true",
+		"when collection is empty, returns false;" +
+			"[]; [A, d, t];" +
+			"false",
+		"when collection and items are empty, returns true;" +
+			"[]; [];" +
+			"true"
+	})
+	void testContainsCollection(String name, @StringCollection Collection<String> items1,
+		@StringCollection Collection<String> items2, boolean expected) {
 
-			assert items1.contains(items2);
-		}
-
-		@Test
-		@DisplayName("returns false when some items are absent")
-		void returnsFalseWhenSomeAbsent() {
-			final var items1 = new TestCollection<>("O", "P", "q");
-			final var items2 = new TestCollection<>("P", "0", "O");
-
-			assert !items1.contains(items2);
-		}
-
-		@Test
-		@DisplayName("returns false when all items are absent")
-		void returnsFalseWhenAllAbsent() {
-			final var items1 = new TestCollection<>("Y", "f", "E", "3");
-			final var items2 = new TestCollection<>("N", "R", "P");
-
-			assert !items1.contains(items2);
-		}
-
-		@Test
-		@DisplayName("returns false when collection is empty")
-		void returnsFalseWhenEmpty() {
-			final var items1 = new TestCollection<String>();
-			final var items2 = new TestCollection<>("G", "Q");
-
-			assert !items1.contains(items2);
-		}
-
-		@Test
-		@DisplayName("returns true when items is empty")
-		void returnsTrueWhenItemsEmpty() {
-			final var items1 = new TestCollection<>("A", "t", "I", "P");
-			final var items2 = new TestCollection<String>();
-
-			assert items1.contains(items2);
-		}
-
-		@Test
-		@DisplayName("returns true when collection and items are empty")
-		void returnsTrueWhenBothEmpty() {
-			final var items1 = new TestCollection<String>();
-			final var items2 = new TestCollection<String>();
-
-			assert items1.contains(items2);
-		}
+		final var contains = items1.contains(items2);
+		assertEquals(expected, contains);
 	}
 
-	@Nested
 	@DisplayName(".match(Predicate<T>)")
-	class MatchTests {
-		@Test
-		@DisplayName("returns matched item when item matches")
-		void returnsItemWhenAnyMatches() {
-			final var items = new TestCollection<>(9, 3, 7, 8, 5, 2);
-			final var match = items.match((item) ->
-				item % 2 == 0);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when some item matches, returns matched item;" +
+			"[F, V, d, P, a, Q];" +
+			"d",
+		"when no item matches, returns empty optional;" +
+			"[F, V, D, P, A, Q];" +
+			" ",
+		"when collection is empty, returns empty optional;" +
+			"[];" +
+			" "
+	})
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	void testMatch(String name, @StringCollection Collection<String> items,
+		@StringOptional Optional<String> expected) {
 
-			assert Optional.of(8)
-				.equals(match);
-		}
+		final var matched = items.match((item) -> {
+			return item.toLowerCase()
+				.equals(item);
+		});
 
-		@Test
-		@DisplayName("returns empty when no item matches")
-		void returnsEmptyWhenNoneMatches() {
-			final var items = new TestCollection<>(9, 3, 7, 5, 5, 1);
-			final var match = items.match((item) ->
-				item % 2 == 0);
-
-			assert match.isEmpty();
-		}
-
-		@Test
-		@DisplayName("returns empty when collection is empty")
-		void returnsEmptyWhenEmpty() {
-			final var items = new TestCollection<Integer>();
-			final var match = items.match((item) ->
-				item % 2 == 0);
-
-			assert match.isEmpty();
-		}
+		assertEquals(expected, matched);
 	}
 
-	@Nested
 	@DisplayName(".noneMatches(Predicate<T>)")
-	class NoneMatchesTests {
-		@Test
-		@DisplayName("returns true when no item matches")
-		void returnsTrueWhenNoneMatches() {
-			final var items = new TestCollection<>(3, 7, 1, 9, 11, 5);
-			assert items.noneMatches((item) ->
-				item % 2 == 0);
-		}
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when no item matches, returns true;" +
+			"[K, M, T, S, A];" +
+			"true",
+		"when some item matches, returns false;" +
+			"[K, m, t, S, a];" +
+			"false",
+		"when each items matches, returns false;" +
+			"[k, m, t, s, a];" +
+			"false",
+		"when collection is empty, returns true;" +
+			"[];" +
+			"true",
+	})
+	void testNoneMatches(String name, @StringCollection Collection<String> items,
+		boolean expected) {
 
-		@Test
-		@DisplayName("returns false when any item matches")
-		void returnsFalseWhenAnyMatches() {
-			final var items = new TestCollection<>(5, 7, 1, 4, 9, 2);
-			assert !items.noneMatches((item) ->
-				item % 2 == 0);
-		}
+		final var noneMatches = items.noneMatches((item) -> {
+			return item.toLowerCase()
+				.equals(item);
+		});
 
-		@Test
-		@DisplayName("returns false when each item matches")
-		void returnsFalseWhenEachMatches() {
-			final var items = new TestCollection<>(8, 6, 2, 4);
-			assert !items.noneMatches((item) ->
-				item % 2 == 0);
-		}
-
-		@Test
-		@DisplayName("returns true when collection is empty")
-		void returnsTrueWhenEmpty() {
-			final var items = new TestCollection<Integer>();
-			assert items.noneMatches((item) ->
-				item % 2 == 0);
-		}
+		assertEquals(expected, noneMatches);
 	}
 
-	@Nested
 	@DisplayName(".anyMatches(Predicate<T>)")
-	class AnyMatchesTests {
-		@Test
-		@DisplayName("returns true when any item matches")
-		void returnsTrueWhenAnyMatches() {
-			final var items = new TestCollection<>(5, 7, 1, 4, 9, 2);
-			assert items.anyMatches((item) ->
-				item % 2 == 0);
-		}
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when no item matches, returns false;" +
+			"[Y, P, D, A, S, M, S];" +
+			"false",
+		"when some item matches, returns true;" +
+			"[Y, P, d, a, S, M, S];" +
+			"true",
+		"when each items matches, returns true;" +
+			"[y, p, d, a, s, m, s];" +
+			"true",
+		"when collection is empty, returns false;" +
+			"[];" +
+			"false",
+	})
+	void testAnyMatches(String name, @StringCollection Collection<String> items,
+		boolean expected) {
 
-		@Test
-		@DisplayName("returns true when each item matches")
-		void returnsTrueWhenEachMatches() {
-			final var items = new TestCollection<>(8, 6, 2, 4);
-			assert items.anyMatches((item) ->
-				item % 2 == 0);
-		}
+		final var anyMatches = items.anyMatches((item) -> {
+			return item.toLowerCase()
+				.equals(item);
+		});
 
-		@Test
-		@DisplayName("returns false when no item matches")
-		void returnsFalseWhenNoneMatches() {
-			final var items = new TestCollection<>(3, 7, 1, 9, 11, 5);
-			assert !items.anyMatches((item) ->
-				item % 2 == 0);
-		}
-
-		@Test
-		@DisplayName("returns false when collection is empty")
-		void returnsFalseWhenEmpty() {
-			final var items = new TestCollection<Integer>();
-			assert !items.anyMatches((item) ->
-				item % 2 == 0);
-		}
+		assertEquals(expected, anyMatches);
 	}
 
-	@Nested
 	@DisplayName(".eachMatches(Predicate<T>)")
-	class EachMatchesTests {
-		@Test
-		@DisplayName("returns true when each items matches")
-		void returnsTrueWhenEachMatches() {
-			final var items = new TestCollection<>(8, 6, 2, 4);
-			assert items.eachMatches((item) ->
-				item % 2 == 0);
-		}
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when no item matches, returns false;" +
+			"[H, B, S, A];" +
+			"false",
+		"when some item matches, returns false;" +
+			"[H, b, S, a];" +
+			"false",
+		"when each items match, returns true;" +
+			"[h, b, s, a];" +
+			"true",
+		"when collection is empty, returns true;" +
+			"[];" +
+			"true",
+	})
+	void testEachMatches(String name, @StringCollection Collection<String> items,
+		boolean expected) {
 
+		final var anyMatches = items.eachMatches((item) -> {
+			return item.toLowerCase()
+				.equals(item);
+		});
 
-		@Test
-		@DisplayName("returns false when any item matches")
-		void returnsFalseWhenAnyMatches() {
-			final var items = new TestCollection<>(5, 7, 1, 4, 9, 2);
-			assert !items.eachMatches((item) ->
-				item % 2 == 0);
-		}
-
-		@Test
-		@DisplayName("returns false when no item matches")
-		void returnsFalseWhenNoneMatches() {
-			final var items = new TestCollection<>(3, 7, 1, 9, 11, 5);
-			assert !items.eachMatches((item) ->
-				item % 2 == 0);
-		}
-
-		@Test
-		@DisplayName("returns true when collection is empty")
-		void returnsTrueWhenEmpty() {
-			final var items = new TestCollection<Integer>();
-			assert items.eachMatches((item) ->
-				item % 2 == 0);
-		}
+		assertEquals(expected, anyMatches);
 	}
 
-	@Nested
 	@DisplayName(".iterate(Consumer<T>)")
-	class IterateTests {
-		@Test
-		@DisplayName("iterates when collection is not empty")
-		void iteratesWhenNotEmpty() {
-			final var items = new TestCollection<>(3, 7, 1, 2, 3, 0);
-			final var iterated = new LinkedList<Integer>();
-			items.iterate(iterated::add);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, iterates items;" +
+			"[f, F, e, q, p, L];" +
+			"[f, F, e, q, p, L]",
+		"when collection is empty, does nothing;" +
+			"[];" +
+			"[]"
+	})
+	void testIterate(String name, @StringCollection Collection<String> items,
+		@StringArray String[] expected) {
 
-			assert java.util.List.of(3, 7, 1, 2, 3, 0)
-				.equals(iterated);
-		}
+		final var iterated = new ArrayList<String>();
+		items.iterate(iterated::add);
 
-		@Test
-		@DisplayName("does nothing when collection is empty")
-		void doesNothingWhenEmpty() {
-			final var items = new TestCollection<Integer>();
-			final var iterated = new LinkedList<Integer>();
-			items.iterate(iterated::add);
-
-			assert java.util.List.of()
-				.equals(iterated);
-		}
+		assertArrayEquals(expected,
+			iterated.toArray(new String[]{
+			}));
 	}
 
-	@Nested
 	@DisplayName(".combine(R, BiFunction<R, T, R>)")
-	class CombineTests {
-		@Test
-		@DisplayName("combines when collection is not empty")
-		void combinesWhenNotEmpty() {
-			final var items = new TestCollection<>(5, 3, 2, 9, 4, 7);
-			final var sum = items.combine(4, Integer::sum);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, combines items with initial value;" +
+			"[g, E, Q, s, a, B]; B;" +
+			"BgEQsaB",
+		"when collection is empty, returns initial value;" +
+			"[]; A;" +
+			"A"
+	})
+	void testCombine(String name, @StringCollection Collection<String> items,
+		String initial, String expected) {
 
-			assert 34 == sum;
-		}
+		final var combined = items.combine(initial, (combined2, item) -> {
+			return combined2 + item;
+		});
 
-		@Test
-		@DisplayName("does nothing when collection is empty")
-		void doesNothingWhenEmpty() {
-			final var items = new TestCollection<Integer>();
-			final var sum = items.combine(4, Integer::sum);
-
-			assert 4 == sum;
-		}
+		assertEquals(expected, combined);
 	}
 
-	@Nested
 	@DisplayName(".join(String)")
-	class JoinTests {
-		@Test
-		@DisplayName("joins items into a string when collection is not empty")
-		void joinsWhenNotEmpty() {
-			final var items = new TestCollection<>("B", "3", "A", "4", "n");
-			final var joined = items.join(", ");
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, joins items into a string;" +
+			"[g, t, W, q, P, l]; -;" +
+			"g-t-W-q-P-l",
+		"when collection is empty, returns empty string;" +
+			"[]; -;" +
+			" "
+	})
+	void testJoin(String name, @StringCollection Collection<String> items,
+		String separator, String expected) {
 
-			assert "B, 3, A, 4, n"
-				.equals(joined);
+		if (expected == null) {
+			expected = "";
 		}
 
-		@Test
-		@DisplayName("returns empty string when collection is empty")
-		void doesNothingWhenEmpty() {
-			final var items = new TestCollection<>();
-			final var joined = items.join(", ");
-
-			assert ""
-				.equals(joined);
-		}
+		final var joined = items.join(separator);
+		assertEquals(expected, joined);
 	}
 
-	@Nested
 	@DisplayName(".toArray()")
-	class ToArrayTests {
-		@Test
-		@DisplayName("when collection is not empty, returns items in array")
-		void returnsArrayWhenNotEmpty() {
-			final var items = new TestCollection<>("T", "b", "4", "0", "O");
-			final var array = items.toArray();
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when collection is not empty, returns items array;" +
+			"[T, b, 4, 0, O];" +
+			"[T, b, 4, 0, O]",
+		"when collection is empty, returns empty array;" +
+			"[];" +
+			"[]"
+	})
+	void testToArray(String name, @StringCollection Collection<String> items,
+		@StringArray String[] expected) {
 
-			assert Arrays.equals(array,
-				new String[]{
-					"T", "b", "4", "0", "O"
-				});
+		final var array = items.toArray();
+		assertArrayEquals(expected, array);
+	}
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConvertWith(StringArray.Converter.class)
+@interface StringArray {
+	class Converter extends TypedArgumentConverter<String, String[]> {
+		protected Converter() {
+			super(String.class, String[].class);
 		}
 
-		@Test
-		@DisplayName("when collection is empty, returns empty array")
-		void returnsEmptyArrayWhenEmpty() {
-			final var items = new TestCollection<>();
-			final var array = items.toArray();
+		@Override
+		protected String[] convert(String s) throws ArgumentConversionException {
+			final var substring = s.substring(
+				s.indexOf("[") + 1,
+				s.lastIndexOf("]"));
 
-			assert Arrays.equals(array,
-				new String[]{});
+			if (substring.isBlank()) {
+				return new String[0];
+			} else {
+				final var string = substring.split("\\s*,\\s*");
+
+				return Arrays.stream(string)
+					.filter((item) -> !item.equals("null"))
+					.toArray(String[]::new);
+			}
 		}
 	}
+}
 
-	static class TestCollection<T> implements Collection<T> {
-		private final Object[] items;
-
-		@SafeVarargs
-		public TestCollection(T... items) {
-			this.items = items;
+@ConvertWith(StringOptional.Converter.class)
+@Retention(RetentionPolicy.RUNTIME)
+@interface StringOptional {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, Optional> {
+		protected Converter() {
+			super(String.class, Optional.class);
 		}
 
 		@Override
-		public List<T> sort(Comparator<T> comparator) {
-			throw new UnsupportedOperationException();
+		protected Optional<String> convert(String s) throws ArgumentConversionException {
+			return Optional.ofNullable(s)
+				.filter((s2) -> !s2.equals("null"));
+		}
+	}
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConvertWith(StringCollection.Converter.class)
+@interface StringCollection {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, Collection> {
+		protected Converter() {
+			super(String.class, Collection.class);
 		}
 
 		@Override
-		public Collection<T> filter(Predicate<T> condition) {
-			throw new UnsupportedOperationException();
-		}
+		protected Collection<String> convert(String s) throws ArgumentConversionException {
+			final var items = new StringArray.Converter()
+				.convert(s);
 
-		@Override
-		public <R> Collection<R> convert(Function<T, R> converter) {
-			throw new UnsupportedOperationException();
-		}
-
-		@Override
-		public Iterator<T> iterator() {
-			return new Iterator<>() {
-				private int index = 0;
-
-				@Override
-				public boolean hasNext() {
-					return index < items.length;
-				}
-
-				@Override
-				public T next() {
-					@SuppressWarnings("unchecked")
-					var item = (T) items[index];
-					++index;
-					return item;
-				}
+			return new AbstractArrayCollection<>(items) {
 			};
 		}
+	}
+}
+
+abstract class AbstractArrayCollection<T> implements Collection<T> {
+	private final Object[] items;
+
+	@SafeVarargs
+	protected AbstractArrayCollection(T... items) {
+		this.items = items;
+	}
+
+	@Override
+	public List<T> sort(Comparator<T> comparator) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Collection<T> filter(Predicate<T> condition) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <R> Collection<R> convert(Function<T, R> converter) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterator<T> iterator() {
+		return new Iterator<>() {
+			private int index = 0;
+
+			@Override
+			public boolean hasNext() {
+				return index < items.length;
+			}
+
+			@Override
+			public T next() {
+				@SuppressWarnings("unchecked")
+				var item = (T) items[index];
+				++index;
+				return item;
+			}
+		};
 	}
 }
 

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -278,8 +278,23 @@ public class CollectionTests {
 		Assertions.assertEquals(expected, sorted);
 	}
 
-	@Nested
+	@DisplayName(".<T not Comparable>sort()")
+	@Test
+	void testSortNotComparable() {
+		Assertions.assertThrows(RuntimeException.class,
+			() -> {
+				final var collection = new AbstractPredicateCollection<>(
+					String::isEmpty,
+					String::isBlank
+				) {
+				};
+
+				collection.sort();
+			});
+	}
+
 	@DisplayName(".shuffle(Random)")
+	@Nested
 	class TestShuffleRandom {
 		@Test
 		@DisplayName("when collection is not empty, returns shuffled list")
@@ -300,8 +315,8 @@ public class CollectionTests {
 			}
 		}
 
-		@Test
 		@DisplayName("when collection is empty, returns empty list")
+		@Test
 		void testWhenEmpty() {
 			Collection<String> items = new AbstractArrayCollection<>() {
 			};
@@ -315,8 +330,8 @@ public class CollectionTests {
 		}
 	}
 
-	@Nested
 	@DisplayName(".shuffle()")
+	@Nested
 	class TestShuffle {
 		@Test
 		@DisplayName("when collection is not empty, returns shuffled list")
@@ -333,8 +348,8 @@ public class CollectionTests {
 			}
 		}
 
-		@Test
 		@DisplayName("when collection is empty, returns empty list")
+		@Test
 		void testWhenEmpty() {
 			Collection<String> items = new AbstractArrayCollection<>() {
 			};
@@ -424,7 +439,8 @@ public class CollectionTests {
 		assertArrayEquals(expected, array);
 	}
 
-	static void assertShuffled(Collection<String> shuffled, Collection<String> unshuffled) {
+	static void assertShuffled
+		(Collection<String> shuffled, Collection<String> unshuffled) {
 		// todo: change to var once cast in .toArray() is resolved
 		final Object[] items1 = shuffled.toArray();
 		final Object[] items2 = unshuffled.toArray();
@@ -505,7 +521,7 @@ public class CollectionTests {
 }
 
 abstract class AbstractArrayCollection<T> implements Collection<T> {
-	private final Object[] items;
+	final Object[] items;
 
 	@SafeVarargs
 	protected AbstractArrayCollection(T... items) {
@@ -540,6 +556,30 @@ abstract class AbstractArrayCollection<T> implements Collection<T> {
 				return item;
 			}
 		};
+	}
+}
+
+abstract class AbstractPredicateCollection<T> implements Collection<Predicate<T>> {
+	final Predicate<T>[] items;
+
+	@SafeVarargs
+	public AbstractPredicateCollection(Predicate<T>... items) {
+		this.items = items;
+	}
+
+	@Override
+	public Collection<Predicate<T>> filter(Predicate<Predicate<T>> condition) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public <R> Collection<R> convert(Function<Predicate<T>, R> converter) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterator<Predicate<T>> iterator() {
+		throw new UnsupportedOperationException();
 	}
 }
 

--- a/src/test/java/co/tsyba/core/collections/ContiguousArrayStoreTests.java
+++ b/src/test/java/co/tsyba/core/collections/ContiguousArrayStoreTests.java
@@ -4,10 +4,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.Random;
-
 import static co.tsyba.core.collections.Assertions.assertEquals;
 
 class ContiguousArrayStoreTests {
@@ -1061,105 +1057,9 @@ class ContiguousArrayStoreTests {
 		}
 	}
 
-	@Nested
-	@DisplayName(".sort(Comparator<T>)")
-	class SortTests {
-		@Test
-		@DisplayName("when store is not empty, sorts items")
-		void sortsItemsWhenStoreNotEmpty() {
-			final var store = new ContiguousArrayStore(
-				new String[]{
-					"v", "R", "e", "C", "q", null, null
-				});
-
-			final var sorted = store.<String>sort(Comparator.naturalOrder());
-
-			assertItemCount(sorted, 5);
-			assertEquals(sorted,
-				new String[]{
-					"C", "R", "e", "q", "v", null, null
-				});
-
-		}
-
-		@Test
-		@DisplayName("when store is empty, does nothing")
-		void doesNothingWhenStoreEmpty() {
-			final var store = new ContiguousArrayStore(
-				new String[]{
-					null, null, null, null
-				});
-
-			final var sorted = store.<String>sort(Comparator.naturalOrder());
-
-			assertItemCount(sorted, 0);
-			assertEquals(sorted,
-				new String[]{
-					null, null, null, null
-				});
-
-		}
-	}
-
-	@Nested
-	@DisplayName(".shuffle(Random)")
-	class ShuffleTests {
-		@Test
-		@DisplayName("when store is not empty, shuffles items")
-		void shufflesItemsWhenStoreNotEmpty() {
-			final var store = new ContiguousArrayStore(
-				new String[]{
-					"v", "M", "l", "P", null, null, null
-				});
-
-			final var random = new Random();
-			final var shuffled = store.shuffle(random);
-
-			assertItemCount(shuffled, 4);
-			assertShuffled(shuffled, store, 4);
-		}
-
-		@Test
-		@DisplayName("when store is empty, does nothing")
-		void doesNothingWhenStoreEmpty() {
-			final var store = new ContiguousArrayStore(
-				new String[]{
-					null, null, null, null
-				});
-
-			final var random = new Random();
-			final var shuffled = store.shuffle(random);
-
-			assertItemCount(shuffled, 0);
-			assertEquals(shuffled,
-				new String[]{
-					null, null, null, null
-				});
-		}
-	}
-
 	private static void assertItemCount(ContiguousArrayStore store, int expected) {
 		assertEquals(store.itemCount, expected,
 			"Item count differs from expectation.");
-	}
-
-	private static void assertShuffled(ContiguousArrayStore shuffled, ContiguousArrayStore original, int itemCount) {
-		// verify shuffled store preserves item capacity
-		assert shuffled.items.length == original.items.length;
-
-		// verify items part of shuffled store differs from the original
-		assert !Arrays.equals(shuffled.items, 0, itemCount,
-			original.items, 0, itemCount);
-
-		// verify capacity part of shuffled store is the same as the original
-		assert Arrays.equals(shuffled.items, itemCount, shuffled.items.length,
-			original.items, itemCount, original.items.length);
-
-		// verify shuffled array contains all items of the original
-		Arrays.sort(shuffled.items, 0, itemCount);
-		Arrays.sort(original.items, 0, itemCount);
-		assert Arrays.equals(shuffled.items, 0, itemCount,
-			original.items, 0, itemCount);
 	}
 }
 

--- a/src/test/java/co/tsyba/core/collections/MutableMapTests.java
+++ b/src/test/java/co/tsyba/core/collections/MutableMapTests.java
@@ -6,799 +6,799 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class MutableMapTests {
-	@Nested
-	@DisplayName(".get(K, V)")
-	class GetTests {
-		@Nested
-		@DisplayName("when map is not empty")
-		class NotEmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-				new Map.Entry<>("F", 5),
-				new Map.Entry<>("R", 3),
-				new Map.Entry<>("g", 9));
-
-			@Test
-			@DisplayName("when key is present, does not store and returns stored value")
-			void returnsStoredValueWhenKeyPresent() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get("R", 0);
-
-				assert 3 == value;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when key is absent, stores and returns argument value")
-			void returnsArgValueWhenKeyAbsent() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get("r", 0);
-
-				final var expected = new MutableSet<>(proto)
-					.add(new Map.Entry<>("r", 0));
-
-				assert 0 == value;
-				assert new Set<>(entries.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when key is present and argument value is null, does not store and returns stored value")
-			void returnsStoredValueWhenKeyPresentArgValueNull() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get("F", null);
-
-				assert 5 == value;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when key is absent and argument value is null, does not store and returns null")
-			void returnsNullWhenKeyAbsentArgValueNull() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get("X", null);
-
-				assert null == value;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when key is null, does not store but returns argument value")
-			void returnsArgValueWhenKeyNull() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get(null, 9);
-
-				assert 9 == value;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when key and argument value are null, does not store and returns null")
-			void returnsNullWhenKeyArgValueNull() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get(null, null);
-
-				assert null == value;
-				assert entries.store
-					.equals(proto);
-			}
-		}
-
-		@Nested
-		@DisplayName("when map is empty")
-		class EmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-
-			@Test
-			@DisplayName("stores and returns argument value")
-			void returnsArgValue() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get("F", 3);
-
-				final var expected = new MutableSet<>(proto)
-					.add(new Map.Entry<>("F", 3));
-
-				assert 3 == value;
-				assert new Set<>(entries.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when key is null, does not store but returns argument value")
-			void returnsArgValueWhenKeyNull() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get(null, 9);
-
-				assert 9 == value;
-				assert entries.store
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when argument value is null, does not store and returns null")
-			void returnsNullWhenArgValueNull() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get("F", null);
-
-				assert null == value;
-				assert entries.store
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when key and argument value are null, does not store and returns null")
-			void returnsNullWhenKeyArgValueNull() {
-				final var entries = new MutableMap<>(proto);
-				final var value = entries.get(null, null);
-
-				assert null == value;
-				assert entries.store
-					.equals(proto);
-			}
-		}
-	}
-
-	@Nested
-	@DisplayName(".set(K, V)")
-	class SetTests {
-		private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-			new Map.Entry<>("G", 7),
-			new Map.Entry<>("x", 0));
-
-		@Test
-		@DisplayName("when key is absent, inserts new entry")
-		void insertsEntryWhenKeyAbsent() {
-			final var entries = new MutableMap<>(proto);
-			final var returned = entries.set("B", 4);
-
-			final var expected = new MutableSet<>(proto)
-				.add(new Map.Entry<>("B", 4));
-
-			assert entries == returned;
-			assert new Set<>(entries.store)
-				.equals(expected);
-		}
-
-		@Test
-		@DisplayName("when key already present, replaces stored value")
-		void replacesStoredValueWhenKeyPresent() {
-			final var entries = new MutableMap<>(proto);
-			final var returned = entries.set("x", 4);
-
-			final var expected = new Set<>(
-				new Map.Entry<>("G", 7),
-				new Map.Entry<>("x", 4));
-
-			assert entries == returned;
-			assert new Set<>(entries.store)
-				.equals(expected);
-		}
-
-		@Test
-		@DisplayName("when key is null, does nothing")
-		void doesNothingWhenKeyNull() {
-			final var entries = new MutableMap<>(proto);
-			final var returned = entries.set(null, 4);
-
-			assert entries == returned;
-			assert entries.store
-				.equals(proto);
-		}
-
-		@Test
-		@DisplayName("when value is null, does nothing")
-		void doesNothingWhenValueNull() {
-			final var entries = new MutableMap<>(proto);
-			final var returned = entries.set("H", null);
-
-			assert entries == returned;
-			assert entries.store
-				.equals(proto);
-		}
-	}
-
-	@Nested
-	@DisplayName(".add(Map<K, V>)")
-	class AddMapTests {
-		@Nested
-		@DisplayName("when map is not empty")
-		class NotEmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-				new Map.Entry<>("B", 0),
-				new Map.Entry<>("J", 9),
-				new Map.Entry<>("s", 4));
-
-			@Test
-			@DisplayName("when all keys are absent, adds entries")
-			void addsEntriesWhenAllKeysAbsent() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<>(
-					new Map.Entry<>("N", 9),
-					new Map.Entry<>("p", 1));
-
-				final var returned = entries1.add(entries2);
-
-				final var expected = new Set<>(
-					new Map.Entry<>("B", 0),
-					new Map.Entry<>("J", 9),
-					new Map.Entry<>("s", 4),
-					new Map.Entry<>("N", 9),
-					new Map.Entry<>("p", 1));
-
-				assert returned == entries1;
-				assert new Set<>(entries1.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when some keys are present, replaces their values")
-			void replacesValuesWhenSomeKeysPresent() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<>(
-					new Map.Entry<>("B", 9),
-					new Map.Entry<>("s", 1));
-
-				final var returned = entries1.add(entries2);
-
-				final var expected = new Set<>(
-					new Map.Entry<>("B", 9),
-					new Map.Entry<>("J", 9),
-					new Map.Entry<>("s", 1));
-
-				assert returned == entries1;
-				assert new Set<>(entries1.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when argument map is empty, does nothing")
-			void doesNothingWhenArgMapEmpty() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<String, Integer>();
-
-				final var returned = entries1.add(entries2);
-
-				assert returned == entries1;
-				assert new Set<>(entries1.store)
-					.equals(proto);
-			}
-		}
-
-		@Nested
-		@DisplayName("when map is empty")
-		class EmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-
-			@Test
-			@DisplayName("adds entries")
-			void addsEntries() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<>(
-					new Map.Entry<>("K", 9),
-					new Map.Entry<>("m", 8));
-
-				final var returned = entries1.add(entries2);
-
-				final var expected = new Set<>(
-					new Map.Entry<>("K", 9),
-					new Map.Entry<>("m", 8));
-
-				assert returned == entries1;
-				assert new Set<>(entries1.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when argument map is empty, does nothing")
-			void doesNothingWhenArgMapEmpty() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<String, Integer>();
-
-				final var returned = entries1.add(entries2);
-
-				assert returned == entries1;
-				assert new Set<>(entries1.store)
-					.isEmpty();
-			}
-		}
-	}
-
-	@Nested
-	@DisplayName(".add(Map<K, V>, BiFunction<V, V, V>)")
-	class AddMapBiFunctionTests {
-		@Nested
-		@DisplayName("when map is not empty")
-		class NotEmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-				new Map.Entry<>("V", 2),
-				new Map.Entry<>("G", 1),
-				new Map.Entry<>("e", 9),
-				new Map.Entry<>("I", 7));
-
-			@Test
-			@DisplayName("when all keys are absent, adds entries")
-			void addsEntriesWhenAllKeysAbsent() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<>(
-					new Map.Entry<>("g", 3),
-					new Map.Entry<>("K", 4));
-
-				final var keys = new MutableSet<String>();
-				final var returned = entries1.add(entries2,
-					(key, value1, value2) -> {
-						keys.add(key);
-						return value2;
-					});
-
-				final var expected = new Set<>(
-					new Map.Entry<>("V", 2),
-					new Map.Entry<>("G", 1),
-					new Map.Entry<>("e", 9),
-					new Map.Entry<>("I", 7),
-					new Map.Entry<>("g", 3),
-					new Map.Entry<>("K", 4));
-
-				assert returned == entries1;
-				assert keys.isEmpty();
-
-				assert new Set<>(entries1.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when some keys are present, resolves their values")
-			void resolvesValuesWhenSomeKeysPresent() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<>(
-					new Map.Entry<>("G", 3),
-					new Map.Entry<>("K", 4),
-					new Map.Entry<>("I", 4));
-
-				final var keys = new MutableSet<String>();
-				final var returned = entries1.add(entries2,
-					(key, value1, value2) -> {
-						keys.add(key);
-						return value2 + 2;
-					});
-
-				final var expected = new Set<>(
-					new Map.Entry<>("V", 2),
-					new Map.Entry<>("G", 5),
-					new Map.Entry<>("e", 9),
-					new Map.Entry<>("I", 6),
-					new Map.Entry<>("K", 4));
-
-				assert returned == entries1;
-				assert new Set<>("G", "I")
-					.equals(keys);
-
-				assert new Set<>(entries1.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when resolver returns null, preserves stored value")
-			void preservesValueWhenResolverReturnsNull() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<>(
-					new Map.Entry<>("G", 3),
-					new Map.Entry<>("K", 4),
-					new Map.Entry<>("I", 4),
-					new Map.Entry<>("e", 7));
-
-				final var keys = new MutableSet<String>();
-				final var returned = entries1.add(entries2,
-					(key, value1, value2) -> {
-						keys.add(key);
-						return value2 > 3 ? null : value2;
-					});
-
-				final var expected = new Set<>(
-					new Map.Entry<>("V", 2),
-					new Map.Entry<>("G", 3),
-					new Map.Entry<>("e", 9),
-					new Map.Entry<>("I", 7),
-					new Map.Entry<>("K", 4));
-
-				assert returned == entries1;
-				assert new Set<>("G", "I", "e")
-					.equals(keys);
-
-				assert new Set<>(entries1.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when argument map is empty, does nothing")
-			void doesNothingWhenArgMapEmpty() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<String, Integer>();
-
-				final var keys = new MutableSet<String>();
-				final var returned = entries1.add(entries2,
-					(key, value1, value2) -> {
-						keys.add(key);
-						return value2;
-					});
-
-				assert returned == entries1;
-				assert keys.isEmpty();
-
-				assert new Set<>(entries1.store)
-					.equals(proto);
-			}
-		}
-
-		@Nested
-		@DisplayName("when map is empty")
-		class EmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-
-			@Test
-			@DisplayName("adds all entries")
-			void addsAllEntries() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<>(
-					new Map.Entry<>("G", 3),
-					new Map.Entry<>("e", 7));
-
-				final var keys = new MutableSet<String>();
-				final var returned = entries1.add(entries2,
-					(key, value1, value2) -> {
-						keys.add(key);
-						return value2;
-					});
-
-				final var expected = new Set<>(
-					new Map.Entry<>("G", 3),
-					new Map.Entry<>("e", 7));
-
-				assert returned == entries1;
-				assert keys.isEmpty();
-
-				assert new Set<>(entries1.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when argument map is empty, does nothing")
-			void doesNothingWhenArgMapEmpty() {
-				final var entries1 = new MutableMap<>(proto);
-				final var entries2 = new Map<String, Integer>();
-
-				final var keys = new MutableSet<String>();
-				final var returned = entries1.add(entries2,
-					(key, value1, value2) -> {
-						keys.add(key);
-						return value2;
-					});
-
-				assert returned == entries1;
-				assert keys.isEmpty();
-
-				assert new Set<>(entries1.store)
-					.equals(proto);
-			}
-		}
-	}
-
-	@Nested
-	@DisplayName(".remove(K)")
-	class RemoveTests {
-		@Nested
-		@DisplayName("when map is not empty")
-		class NotEmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-				new Map.Entry<>("P", 5),
-				new Map.Entry<>("l", 4),
-				new Map.Entry<>("M", 3),
-				new Map.Entry<>("F", 5));
-
-			@Test
-			@DisplayName("when key is present, removes its entry")
-			void removesEntryWhenKeyPresent() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove("M");
-
-				final var expected = new Set<>(
-					new Map.Entry<>("P", 5),
-					new Map.Entry<>("l", 4),
-					new Map.Entry<>("F", 5));
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when key is absent, does nothing")
-			void doesNothingWhenKeyAbsent() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove("m");
-
-				assert returned == entries;
-				assert entries.store
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when key is null, does nothing")
-			void doesNothingWhenKeyNull() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove((String) null);
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-		}
-
-		@Nested
-		@DisplayName("when map is empty")
-		class EmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-
-			@Test
-			@DisplayName("does nothing")
-			void doesNothing() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove("b");
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when key is null, does nothing")
-			void doesNothingWhenKeyNull() {
-				final var entries = new MutableMap<String, Integer>();
-				final var returned = entries.remove((String) null);
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-		}
-	}
-
-	@SuppressWarnings("ConstantConditions")
-	@Nested
-	@DisplayName(".remove(K...)")
-	class RemoveVarargsTests {
-		@Nested
-		@DisplayName("when map is not empty")
-		class NotEmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-				new Map.Entry<>("P", 5),
-				new Map.Entry<>("l", 4),
-				new Map.Entry<>("M", 3),
-				new Map.Entry<>("F", 5));
-
-			@Test
-			@DisplayName("when all keys are present, removes their entries")
-			void removesEntriesWhenAllKeysPresent() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove("M", "P", "F");
-
-				final var expected = new Set<>(
-					new Map.Entry<>("l", 4));
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when some keys are present, removes their entries")
-			void removesEntriesWhenSomeKeysPresent() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove("M", "p", "F", "L");
-
-				final var expected = new Set<>(
-					new Map.Entry<>("P", 5),
-					new Map.Entry<>("l", 4));
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when no keys are present, does nothing")
-			void doesNothingWhenNoKeysPresent() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove("V", "b", "L", "w");
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when some keys are null, ignores them")
-			void ignoresNullsWhenSomeKeysNull() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove("m", null, "P", null, null, "F");
-
-				final var expected = new Set<>(
-					new Map.Entry<>("l", 4),
-					new Map.Entry<>("M", 3));
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(expected);
-			}
-		}
-
-		@Nested
-		@DisplayName("when map is empty")
-		class EmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-
-			@Test
-			@DisplayName("does nothing")
-			void doesNothing() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove("b", "F", "w");
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-
-			@Test
-			@DisplayName("when some keys are null, does nothing")
-			void doesNothingWhenSomeKeysNull() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove(null, "V", null, null, "Q");
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-		}
-	}
-
-	@Nested
-	@DisplayName(".remove(Collection<K>)")
-	class RemoveCollectionTests {
-		@Nested
-		@DisplayName("when map is not empty")
-		class NotEmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-				new Map.Entry<>("P", 5),
-				new Map.Entry<>("l", 3),
-				new Map.Entry<>("M", 4),
-				new Map.Entry<>("F", 5));
-
-			@Test
-			@DisplayName("when all keys are present, removes entries")
-			void removesEntriesWhenAllKeysPresent() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove(
-					new Set<>("M", "P", "F"));
-
-				final var expected = new Set<>(
-					new Map.Entry<>("l", 4));
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when some keys are present, removes entries")
-			void removesEntriesWhenSomeKeysPresent() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove(
-					new Set<>("M", "p", "F", "L"));
-
-				final var expected = new Set<>(
-					new Map.Entry<>("P", 5),
-					new Map.Entry<>("l", 4));
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(expected);
-			}
-
-			@Test
-			@DisplayName("when no keys are present, does nothing")
-			void doesNothingWhenNoKeysPresent() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove(
-					new Set<>("V", "b", "L", "w"));
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-		}
-
-		@Nested
-		@DisplayName("when map is empty")
-		class EmptyMapTests {
-			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-
-			@Test
-			@DisplayName("does nothing")
-			void doesNothing() {
-				final var entries = new MutableMap<>(proto);
-				final var returned = entries.remove(
-					new Set<>("b", "F", "w"));
-
-				assert returned == entries;
-				assert new Set<>(entries.store)
-					.equals(proto);
-			}
-		}
-	}
-
-	@Nested
-	@DisplayName(".clear()")
-	class ClearTests {
-		@Test
-		@DisplayName("when map is not empty, removes all entries")
-		void removesAllEntriesWhenNotEmpty() {
-			final var entries = new MutableMap<>(
-				new Map.Entry<>("v", 5),
-				new Map.Entry<>("v", 4),
-				new Map.Entry<>("v", 2),
-				new Map.Entry<>("v", 7));
-
-			final var returned = entries.clear();
-
-			assert returned == entries;
-			assert new Set<>(entries.store)
-				.isEmpty();
-		}
-
-		@Test
-		@DisplayName("when map is empty, does nothing")
-		void doesNothingWhenEmpty() {
-			final var entries = new MutableMap<>();
-			final var returned = entries.clear();
-
-			assert returned == entries;
-			assert new Set<>(entries.store)
-				.isEmpty();
-		}
-	}
-
-	@Nested
-	@DisplayName(".toImmutable()")
-	class ToImmutableTests {
-		@Test
-		@DisplayName("when map is not empty, returns immutable copy")
-		void returnsMapWhenNotEmpty() {
-			final var proto = new Set<>(
-				new Map.Entry<>("G", 0),
-				new Map.Entry<>("x", 3),
-				new Map.Entry<>("q", 1));
-
-			final var entries1 = new MutableMap<>(proto);
-			final var entries2 = entries1.toImmutable();
-
-			assert Map.class == entries2.getClass();
-			assert new Set<>(entries2.store)
-				.equals(proto);
-		}
-
-		@Test
-		@DisplayName("when map is empty, returns empty immutable copy")
-		void returnsEmptyMapWhenEmpty() {
-			final var entries1 = new MutableMap<String, Integer>();
-			final var entries2 = entries1.toImmutable();
-
-			assert Map.class == entries2.getClass();
-			assert new Set<>(entries2.store)
-				.isEmpty();
-		}
-	}
+//	@Nested
+//	@DisplayName(".get(K, V)")
+//	class GetTests {
+//		@Nested
+//		@DisplayName("when map is not empty")
+//		class NotEmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+//				new Map.Entry<>("F", 5),
+//				new Map.Entry<>("R", 3),
+//				new Map.Entry<>("g", 9));
+//
+//			@Test
+//			@DisplayName("when key is present, does not store and returns stored value")
+//			void returnsStoredValueWhenKeyPresent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get("R", 0);
+//
+//				assert 3 == value;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when key is absent, stores and returns argument value")
+//			void returnsArgValueWhenKeyAbsent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get("r", 0);
+//
+//				final var expected = new MutableSet<>(proto)
+//					.add(new Map.Entry<>("r", 0));
+//
+//				assert 0 == value;
+//				assert new Set<>(entries.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when key is present and argument value is null, does not store and returns stored value")
+//			void returnsStoredValueWhenKeyPresentArgValueNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get("F", null);
+//
+//				assert 5 == value;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when key is absent and argument value is null, does not store and returns null")
+//			void returnsNullWhenKeyAbsentArgValueNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get("X", null);
+//
+//				assert null == value;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when key is null, does not store but returns argument value")
+//			void returnsArgValueWhenKeyNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get(null, 9);
+//
+//				assert 9 == value;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when key and argument value are null, does not store and returns null")
+//			void returnsNullWhenKeyArgValueNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get(null, null);
+//
+//				assert null == value;
+//				assert entries.store
+//					.equals(proto);
+//			}
+//		}
+//
+//		@Nested
+//		@DisplayName("when map is empty")
+//		class EmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+//
+//			@Test
+//			@DisplayName("stores and returns argument value")
+//			void returnsArgValue() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get("F", 3);
+//
+//				final var expected = new MutableSet<>(proto)
+//					.add(new Map.Entry<>("F", 3));
+//
+//				assert 3 == value;
+//				assert new Set<>(entries.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when key is null, does not store but returns argument value")
+//			void returnsArgValueWhenKeyNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get(null, 9);
+//
+//				assert 9 == value;
+//				assert entries.store
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when argument value is null, does not store and returns null")
+//			void returnsNullWhenArgValueNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get("F", null);
+//
+//				assert null == value;
+//				assert entries.store
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when key and argument value are null, does not store and returns null")
+//			void returnsNullWhenKeyArgValueNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var value = entries.get(null, null);
+//
+//				assert null == value;
+//				assert entries.store
+//					.equals(proto);
+//			}
+//		}
+//	}
+//
+//	@Nested
+//	@DisplayName(".set(K, V)")
+//	class SetTests {
+//		private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+//			new Map.Entry<>("G", 7),
+//			new Map.Entry<>("x", 0));
+//
+//		@Test
+//		@DisplayName("when key is absent, inserts new entry")
+//		void insertsEntryWhenKeyAbsent() {
+//			final var entries = new MutableMap<>(proto);
+//			final var returned = entries.set("B", 4);
+//
+//			final var expected = new MutableSet<>(proto)
+//				.add(new Map.Entry<>("B", 4));
+//
+//			assert entries == returned;
+//			assert new Set<>(entries.store)
+//				.equals(expected);
+//		}
+//
+//		@Test
+//		@DisplayName("when key already present, replaces stored value")
+//		void replacesStoredValueWhenKeyPresent() {
+//			final var entries = new MutableMap<>(proto);
+//			final var returned = entries.set("x", 4);
+//
+//			final var expected = new Set<>(
+//				new Map.Entry<>("G", 7),
+//				new Map.Entry<>("x", 4));
+//
+//			assert entries == returned;
+//			assert new Set<>(entries.store)
+//				.equals(expected);
+//		}
+//
+//		@Test
+//		@DisplayName("when key is null, does nothing")
+//		void doesNothingWhenKeyNull() {
+//			final var entries = new MutableMap<>(proto);
+//			final var returned = entries.set(null, 4);
+//
+//			assert entries == returned;
+//			assert entries.store
+//				.equals(proto);
+//		}
+//
+//		@Test
+//		@DisplayName("when value is null, does nothing")
+//		void doesNothingWhenValueNull() {
+//			final var entries = new MutableMap<>(proto);
+//			final var returned = entries.set("H", null);
+//
+//			assert entries == returned;
+//			assert entries.store
+//				.equals(proto);
+//		}
+//	}
+//
+//	@Nested
+//	@DisplayName(".add(Map<K, V>)")
+//	class AddMapTests {
+//		@Nested
+//		@DisplayName("when map is not empty")
+//		class NotEmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+//				new Map.Entry<>("B", 0),
+//				new Map.Entry<>("J", 9),
+//				new Map.Entry<>("s", 4));
+//
+//			@Test
+//			@DisplayName("when all keys are absent, adds entries")
+//			void addsEntriesWhenAllKeysAbsent() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<>(
+//					new Map.Entry<>("N", 9),
+//					new Map.Entry<>("p", 1));
+//
+//				final var returned = entries1.add(entries2);
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("B", 0),
+//					new Map.Entry<>("J", 9),
+//					new Map.Entry<>("s", 4),
+//					new Map.Entry<>("N", 9),
+//					new Map.Entry<>("p", 1));
+//
+//				assert returned == entries1;
+//				assert new Set<>(entries1.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when some keys are present, replaces their values")
+//			void replacesValuesWhenSomeKeysPresent() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<>(
+//					new Map.Entry<>("B", 9),
+//					new Map.Entry<>("s", 1));
+//
+//				final var returned = entries1.add(entries2);
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("B", 9),
+//					new Map.Entry<>("J", 9),
+//					new Map.Entry<>("s", 1));
+//
+//				assert returned == entries1;
+//				assert new Set<>(entries1.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when argument map is empty, does nothing")
+//			void doesNothingWhenArgMapEmpty() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<String, Integer>();
+//
+//				final var returned = entries1.add(entries2);
+//
+//				assert returned == entries1;
+//				assert new Set<>(entries1.store)
+//					.equals(proto);
+//			}
+//		}
+//
+//		@Nested
+//		@DisplayName("when map is empty")
+//		class EmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+//
+//			@Test
+//			@DisplayName("adds entries")
+//			void addsEntries() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<>(
+//					new Map.Entry<>("K", 9),
+//					new Map.Entry<>("m", 8));
+//
+//				final var returned = entries1.add(entries2);
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("K", 9),
+//					new Map.Entry<>("m", 8));
+//
+//				assert returned == entries1;
+//				assert new Set<>(entries1.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when argument map is empty, does nothing")
+//			void doesNothingWhenArgMapEmpty() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<String, Integer>();
+//
+//				final var returned = entries1.add(entries2);
+//
+//				assert returned == entries1;
+//				assert new Set<>(entries1.store)
+//					.isEmpty();
+//			}
+//		}
+//	}
+//
+//	@Nested
+//	@DisplayName(".add(Map<K, V>, BiFunction<V, V, V>)")
+//	class AddMapBiFunctionTests {
+//		@Nested
+//		@DisplayName("when map is not empty")
+//		class NotEmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+//				new Map.Entry<>("V", 2),
+//				new Map.Entry<>("G", 1),
+//				new Map.Entry<>("e", 9),
+//				new Map.Entry<>("I", 7));
+//
+//			@Test
+//			@DisplayName("when all keys are absent, adds entries")
+//			void addsEntriesWhenAllKeysAbsent() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<>(
+//					new Map.Entry<>("g", 3),
+//					new Map.Entry<>("K", 4));
+//
+//				final var keys = new MutableSet<String>();
+//				final var returned = entries1.add(entries2,
+//					(key, value1, value2) -> {
+//						keys.add(key);
+//						return value2;
+//					});
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("V", 2),
+//					new Map.Entry<>("G", 1),
+//					new Map.Entry<>("e", 9),
+//					new Map.Entry<>("I", 7),
+//					new Map.Entry<>("g", 3),
+//					new Map.Entry<>("K", 4));
+//
+//				assert returned == entries1;
+//				assert keys.isEmpty();
+//
+//				assert new Set<>(entries1.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when some keys are present, resolves their values")
+//			void resolvesValuesWhenSomeKeysPresent() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<>(
+//					new Map.Entry<>("G", 3),
+//					new Map.Entry<>("K", 4),
+//					new Map.Entry<>("I", 4));
+//
+//				final var keys = new MutableSet<String>();
+//				final var returned = entries1.add(entries2,
+//					(key, value1, value2) -> {
+//						keys.add(key);
+//						return value2 + 2;
+//					});
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("V", 2),
+//					new Map.Entry<>("G", 5),
+//					new Map.Entry<>("e", 9),
+//					new Map.Entry<>("I", 6),
+//					new Map.Entry<>("K", 4));
+//
+//				assert returned == entries1;
+//				assert new Set<>("G", "I")
+//					.equals(keys);
+//
+//				assert new Set<>(entries1.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when resolver returns null, preserves stored value")
+//			void preservesValueWhenResolverReturnsNull() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<>(
+//					new Map.Entry<>("G", 3),
+//					new Map.Entry<>("K", 4),
+//					new Map.Entry<>("I", 4),
+//					new Map.Entry<>("e", 7));
+//
+//				final var keys = new MutableSet<String>();
+//				final var returned = entries1.add(entries2,
+//					(key, value1, value2) -> {
+//						keys.add(key);
+//						return value2 > 3 ? null : value2;
+//					});
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("V", 2),
+//					new Map.Entry<>("G", 3),
+//					new Map.Entry<>("e", 9),
+//					new Map.Entry<>("I", 7),
+//					new Map.Entry<>("K", 4));
+//
+//				assert returned == entries1;
+//				assert new Set<>("G", "I", "e")
+//					.equals(keys);
+//
+//				assert new Set<>(entries1.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when argument map is empty, does nothing")
+//			void doesNothingWhenArgMapEmpty() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<String, Integer>();
+//
+//				final var keys = new MutableSet<String>();
+//				final var returned = entries1.add(entries2,
+//					(key, value1, value2) -> {
+//						keys.add(key);
+//						return value2;
+//					});
+//
+//				assert returned == entries1;
+//				assert keys.isEmpty();
+//
+//				assert new Set<>(entries1.store)
+//					.equals(proto);
+//			}
+//		}
+//
+//		@Nested
+//		@DisplayName("when map is empty")
+//		class EmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+//
+//			@Test
+//			@DisplayName("adds all entries")
+//			void addsAllEntries() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<>(
+//					new Map.Entry<>("G", 3),
+//					new Map.Entry<>("e", 7));
+//
+//				final var keys = new MutableSet<String>();
+//				final var returned = entries1.add(entries2,
+//					(key, value1, value2) -> {
+//						keys.add(key);
+//						return value2;
+//					});
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("G", 3),
+//					new Map.Entry<>("e", 7));
+//
+//				assert returned == entries1;
+//				assert keys.isEmpty();
+//
+//				assert new Set<>(entries1.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when argument map is empty, does nothing")
+//			void doesNothingWhenArgMapEmpty() {
+//				final var entries1 = new MutableMap<>(proto);
+//				final var entries2 = new Map<String, Integer>();
+//
+//				final var keys = new MutableSet<String>();
+//				final var returned = entries1.add(entries2,
+//					(key, value1, value2) -> {
+//						keys.add(key);
+//						return value2;
+//					});
+//
+//				assert returned == entries1;
+//				assert keys.isEmpty();
+//
+//				assert new Set<>(entries1.store)
+//					.equals(proto);
+//			}
+//		}
+//	}
+//
+//	@Nested
+//	@DisplayName(".remove(K)")
+//	class RemoveTests {
+//		@Nested
+//		@DisplayName("when map is not empty")
+//		class NotEmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+//				new Map.Entry<>("P", 5),
+//				new Map.Entry<>("l", 4),
+//				new Map.Entry<>("M", 3),
+//				new Map.Entry<>("F", 5));
+//
+//			@Test
+//			@DisplayName("when key is present, removes its entry")
+//			void removesEntryWhenKeyPresent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove("M");
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("P", 5),
+//					new Map.Entry<>("l", 4),
+//					new Map.Entry<>("F", 5));
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when key is absent, does nothing")
+//			void doesNothingWhenKeyAbsent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove("m");
+//
+//				assert returned == entries;
+//				assert entries.store
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when key is null, does nothing")
+//			void doesNothingWhenKeyNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove((String) null);
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//		}
+//
+//		@Nested
+//		@DisplayName("when map is empty")
+//		class EmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+//
+//			@Test
+//			@DisplayName("does nothing")
+//			void doesNothing() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove("b");
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when key is null, does nothing")
+//			void doesNothingWhenKeyNull() {
+//				final var entries = new MutableMap<String, Integer>();
+//				final var returned = entries.remove((String) null);
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//		}
+//	}
+//
+//	@SuppressWarnings("ConstantConditions")
+//	@Nested
+//	@DisplayName(".remove(K...)")
+//	class RemoveVarargsTests {
+//		@Nested
+//		@DisplayName("when map is not empty")
+//		class NotEmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+//				new Map.Entry<>("P", 5),
+//				new Map.Entry<>("l", 4),
+//				new Map.Entry<>("M", 3),
+//				new Map.Entry<>("F", 5));
+//
+//			@Test
+//			@DisplayName("when all keys are present, removes their entries")
+//			void removesEntriesWhenAllKeysPresent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove("M", "P", "F");
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("l", 4));
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when some keys are present, removes their entries")
+//			void removesEntriesWhenSomeKeysPresent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove("M", "p", "F", "L");
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("P", 5),
+//					new Map.Entry<>("l", 4));
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when no keys are present, does nothing")
+//			void doesNothingWhenNoKeysPresent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove("V", "b", "L", "w");
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when some keys are null, ignores them")
+//			void ignoresNullsWhenSomeKeysNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove("m", null, "P", null, null, "F");
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("l", 4),
+//					new Map.Entry<>("M", 3));
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(expected);
+//			}
+//		}
+//
+//		@Nested
+//		@DisplayName("when map is empty")
+//		class EmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+//
+//			@Test
+//			@DisplayName("does nothing")
+//			void doesNothing() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove("b", "F", "w");
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//
+//			@Test
+//			@DisplayName("when some keys are null, does nothing")
+//			void doesNothingWhenSomeKeysNull() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove(null, "V", null, null, "Q");
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//		}
+//	}
+//
+//	@Nested
+//	@DisplayName(".remove(Collection<K>)")
+//	class RemoveCollectionTests {
+//		@Nested
+//		@DisplayName("when map is not empty")
+//		class NotEmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+//				new Map.Entry<>("P", 5),
+//				new Map.Entry<>("l", 3),
+//				new Map.Entry<>("M", 4),
+//				new Map.Entry<>("F", 5));
+//
+//			@Test
+//			@DisplayName("when all keys are present, removes entries")
+//			void removesEntriesWhenAllKeysPresent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove(
+//					new Set<>("M", "P", "F"));
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("l", 4));
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when some keys are present, removes entries")
+//			void removesEntriesWhenSomeKeysPresent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove(
+//					new Set<>("M", "p", "F", "L"));
+//
+//				final var expected = new Set<>(
+//					new Map.Entry<>("P", 5),
+//					new Map.Entry<>("l", 4));
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(expected);
+//			}
+//
+//			@Test
+//			@DisplayName("when no keys are present, does nothing")
+//			void doesNothingWhenNoKeysPresent() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove(
+//					new Set<>("V", "b", "L", "w"));
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//		}
+//
+//		@Nested
+//		@DisplayName("when map is empty")
+//		class EmptyMapTests {
+//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+//
+//			@Test
+//			@DisplayName("does nothing")
+//			void doesNothing() {
+//				final var entries = new MutableMap<>(proto);
+//				final var returned = entries.remove(
+//					new Set<>("b", "F", "w"));
+//
+//				assert returned == entries;
+//				assert new Set<>(entries.store)
+//					.equals(proto);
+//			}
+//		}
+//	}
+//
+//	@Nested
+//	@DisplayName(".clear()")
+//	class ClearTests {
+//		@Test
+//		@DisplayName("when map is not empty, removes all entries")
+//		void removesAllEntriesWhenNotEmpty() {
+//			final var entries = new MutableMap<>(
+//				new Map.Entry<>("v", 5),
+//				new Map.Entry<>("v", 4),
+//				new Map.Entry<>("v", 2),
+//				new Map.Entry<>("v", 7));
+//
+//			final var returned = entries.clear();
+//
+//			assert returned == entries;
+//			assert new Set<>(entries.store)
+//				.isEmpty();
+//		}
+//
+//		@Test
+//		@DisplayName("when map is empty, does nothing")
+//		void doesNothingWhenEmpty() {
+//			final var entries = new MutableMap<>();
+//			final var returned = entries.clear();
+//
+//			assert returned == entries;
+//			assert new Set<>(entries.store)
+//				.isEmpty();
+//		}
+//	}
+//
+//	@Nested
+//	@DisplayName(".toImmutable()")
+//	class ToImmutableTests {
+//		@Test
+//		@DisplayName("when map is not empty, returns immutable copy")
+//		void returnsMapWhenNotEmpty() {
+//			final var proto = new Set<>(
+//				new Map.Entry<>("G", 0),
+//				new Map.Entry<>("x", 3),
+//				new Map.Entry<>("q", 1));
+//
+//			final var entries1 = new MutableMap<>(proto);
+//			final var entries2 = entries1.toImmutable();
+//
+//			assert Map.class == entries2.getClass();
+//			assert new Set<>(entries2.store)
+//				.equals(proto);
+//		}
+//
+//		@Test
+//		@DisplayName("when map is empty, returns empty immutable copy")
+//		void returnsEmptyMapWhenEmpty() {
+//			final var entries1 = new MutableMap<String, Integer>();
+//			final var entries2 = entries1.toImmutable();
+//
+//			assert Map.class == entries2.getClass();
+//			assert new Set<>(entries2.store)
+//				.isEmpty();
+//		}
+//	}
 }
 
 // created on Sep 1, 2019

--- a/src/test/java/co/tsyba/core/collections/MutableMapTests.java
+++ b/src/test/java/co/tsyba/core/collections/MutableMapTests.java
@@ -6,799 +6,799 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class MutableMapTests {
-//	@Nested
-//	@DisplayName(".get(K, V)")
-//	class GetTests {
-//		@Nested
-//		@DisplayName("when map is not empty")
-//		class NotEmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-//				new Map.Entry<>("F", 5),
-//				new Map.Entry<>("R", 3),
-//				new Map.Entry<>("g", 9));
-//
-//			@Test
-//			@DisplayName("when key is present, does not store and returns stored value")
-//			void returnsStoredValueWhenKeyPresent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get("R", 0);
-//
-//				assert 3 == value;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when key is absent, stores and returns argument value")
-//			void returnsArgValueWhenKeyAbsent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get("r", 0);
-//
-//				final var expected = new MutableSet<>(proto)
-//					.add(new Map.Entry<>("r", 0));
-//
-//				assert 0 == value;
-//				assert new Set<>(entries.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when key is present and argument value is null, does not store and returns stored value")
-//			void returnsStoredValueWhenKeyPresentArgValueNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get("F", null);
-//
-//				assert 5 == value;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when key is absent and argument value is null, does not store and returns null")
-//			void returnsNullWhenKeyAbsentArgValueNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get("X", null);
-//
-//				assert null == value;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when key is null, does not store but returns argument value")
-//			void returnsArgValueWhenKeyNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get(null, 9);
-//
-//				assert 9 == value;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when key and argument value are null, does not store and returns null")
-//			void returnsNullWhenKeyArgValueNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get(null, null);
-//
-//				assert null == value;
-//				assert entries.store
-//					.equals(proto);
-//			}
-//		}
-//
-//		@Nested
-//		@DisplayName("when map is empty")
-//		class EmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-//
-//			@Test
-//			@DisplayName("stores and returns argument value")
-//			void returnsArgValue() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get("F", 3);
-//
-//				final var expected = new MutableSet<>(proto)
-//					.add(new Map.Entry<>("F", 3));
-//
-//				assert 3 == value;
-//				assert new Set<>(entries.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when key is null, does not store but returns argument value")
-//			void returnsArgValueWhenKeyNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get(null, 9);
-//
-//				assert 9 == value;
-//				assert entries.store
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when argument value is null, does not store and returns null")
-//			void returnsNullWhenArgValueNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get("F", null);
-//
-//				assert null == value;
-//				assert entries.store
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when key and argument value are null, does not store and returns null")
-//			void returnsNullWhenKeyArgValueNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var value = entries.get(null, null);
-//
-//				assert null == value;
-//				assert entries.store
-//					.equals(proto);
-//			}
-//		}
-//	}
-//
-//	@Nested
-//	@DisplayName(".set(K, V)")
-//	class SetTests {
-//		private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-//			new Map.Entry<>("G", 7),
-//			new Map.Entry<>("x", 0));
-//
-//		@Test
-//		@DisplayName("when key is absent, inserts new entry")
-//		void insertsEntryWhenKeyAbsent() {
-//			final var entries = new MutableMap<>(proto);
-//			final var returned = entries.set("B", 4);
-//
-//			final var expected = new MutableSet<>(proto)
-//				.add(new Map.Entry<>("B", 4));
-//
-//			assert entries == returned;
-//			assert new Set<>(entries.store)
-//				.equals(expected);
-//		}
-//
-//		@Test
-//		@DisplayName("when key already present, replaces stored value")
-//		void replacesStoredValueWhenKeyPresent() {
-//			final var entries = new MutableMap<>(proto);
-//			final var returned = entries.set("x", 4);
-//
-//			final var expected = new Set<>(
-//				new Map.Entry<>("G", 7),
-//				new Map.Entry<>("x", 4));
-//
-//			assert entries == returned;
-//			assert new Set<>(entries.store)
-//				.equals(expected);
-//		}
-//
-//		@Test
-//		@DisplayName("when key is null, does nothing")
-//		void doesNothingWhenKeyNull() {
-//			final var entries = new MutableMap<>(proto);
-//			final var returned = entries.set(null, 4);
-//
-//			assert entries == returned;
-//			assert entries.store
-//				.equals(proto);
-//		}
-//
-//		@Test
-//		@DisplayName("when value is null, does nothing")
-//		void doesNothingWhenValueNull() {
-//			final var entries = new MutableMap<>(proto);
-//			final var returned = entries.set("H", null);
-//
-//			assert entries == returned;
-//			assert entries.store
-//				.equals(proto);
-//		}
-//	}
-//
-//	@Nested
-//	@DisplayName(".add(Map<K, V>)")
-//	class AddMapTests {
-//		@Nested
-//		@DisplayName("when map is not empty")
-//		class NotEmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-//				new Map.Entry<>("B", 0),
-//				new Map.Entry<>("J", 9),
-//				new Map.Entry<>("s", 4));
-//
-//			@Test
-//			@DisplayName("when all keys are absent, adds entries")
-//			void addsEntriesWhenAllKeysAbsent() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<>(
-//					new Map.Entry<>("N", 9),
-//					new Map.Entry<>("p", 1));
-//
-//				final var returned = entries1.add(entries2);
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("B", 0),
-//					new Map.Entry<>("J", 9),
-//					new Map.Entry<>("s", 4),
-//					new Map.Entry<>("N", 9),
-//					new Map.Entry<>("p", 1));
-//
-//				assert returned == entries1;
-//				assert new Set<>(entries1.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when some keys are present, replaces their values")
-//			void replacesValuesWhenSomeKeysPresent() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<>(
-//					new Map.Entry<>("B", 9),
-//					new Map.Entry<>("s", 1));
-//
-//				final var returned = entries1.add(entries2);
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("B", 9),
-//					new Map.Entry<>("J", 9),
-//					new Map.Entry<>("s", 1));
-//
-//				assert returned == entries1;
-//				assert new Set<>(entries1.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when argument map is empty, does nothing")
-//			void doesNothingWhenArgMapEmpty() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<String, Integer>();
-//
-//				final var returned = entries1.add(entries2);
-//
-//				assert returned == entries1;
-//				assert new Set<>(entries1.store)
-//					.equals(proto);
-//			}
-//		}
-//
-//		@Nested
-//		@DisplayName("when map is empty")
-//		class EmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-//
-//			@Test
-//			@DisplayName("adds entries")
-//			void addsEntries() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<>(
-//					new Map.Entry<>("K", 9),
-//					new Map.Entry<>("m", 8));
-//
-//				final var returned = entries1.add(entries2);
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("K", 9),
-//					new Map.Entry<>("m", 8));
-//
-//				assert returned == entries1;
-//				assert new Set<>(entries1.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when argument map is empty, does nothing")
-//			void doesNothingWhenArgMapEmpty() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<String, Integer>();
-//
-//				final var returned = entries1.add(entries2);
-//
-//				assert returned == entries1;
-//				assert new Set<>(entries1.store)
-//					.isEmpty();
-//			}
-//		}
-//	}
-//
-//	@Nested
-//	@DisplayName(".add(Map<K, V>, BiFunction<V, V, V>)")
-//	class AddMapBiFunctionTests {
-//		@Nested
-//		@DisplayName("when map is not empty")
-//		class NotEmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-//				new Map.Entry<>("V", 2),
-//				new Map.Entry<>("G", 1),
-//				new Map.Entry<>("e", 9),
-//				new Map.Entry<>("I", 7));
-//
-//			@Test
-//			@DisplayName("when all keys are absent, adds entries")
-//			void addsEntriesWhenAllKeysAbsent() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<>(
-//					new Map.Entry<>("g", 3),
-//					new Map.Entry<>("K", 4));
-//
-//				final var keys = new MutableSet<String>();
-//				final var returned = entries1.add(entries2,
-//					(key, value1, value2) -> {
-//						keys.add(key);
-//						return value2;
-//					});
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("V", 2),
-//					new Map.Entry<>("G", 1),
-//					new Map.Entry<>("e", 9),
-//					new Map.Entry<>("I", 7),
-//					new Map.Entry<>("g", 3),
-//					new Map.Entry<>("K", 4));
-//
-//				assert returned == entries1;
-//				assert keys.isEmpty();
-//
-//				assert new Set<>(entries1.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when some keys are present, resolves their values")
-//			void resolvesValuesWhenSomeKeysPresent() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<>(
-//					new Map.Entry<>("G", 3),
-//					new Map.Entry<>("K", 4),
-//					new Map.Entry<>("I", 4));
-//
-//				final var keys = new MutableSet<String>();
-//				final var returned = entries1.add(entries2,
-//					(key, value1, value2) -> {
-//						keys.add(key);
-//						return value2 + 2;
-//					});
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("V", 2),
-//					new Map.Entry<>("G", 5),
-//					new Map.Entry<>("e", 9),
-//					new Map.Entry<>("I", 6),
-//					new Map.Entry<>("K", 4));
-//
-//				assert returned == entries1;
-//				assert new Set<>("G", "I")
-//					.equals(keys);
-//
-//				assert new Set<>(entries1.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when resolver returns null, preserves stored value")
-//			void preservesValueWhenResolverReturnsNull() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<>(
-//					new Map.Entry<>("G", 3),
-//					new Map.Entry<>("K", 4),
-//					new Map.Entry<>("I", 4),
-//					new Map.Entry<>("e", 7));
-//
-//				final var keys = new MutableSet<String>();
-//				final var returned = entries1.add(entries2,
-//					(key, value1, value2) -> {
-//						keys.add(key);
-//						return value2 > 3 ? null : value2;
-//					});
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("V", 2),
-//					new Map.Entry<>("G", 3),
-//					new Map.Entry<>("e", 9),
-//					new Map.Entry<>("I", 7),
-//					new Map.Entry<>("K", 4));
-//
-//				assert returned == entries1;
-//				assert new Set<>("G", "I", "e")
-//					.equals(keys);
-//
-//				assert new Set<>(entries1.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when argument map is empty, does nothing")
-//			void doesNothingWhenArgMapEmpty() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<String, Integer>();
-//
-//				final var keys = new MutableSet<String>();
-//				final var returned = entries1.add(entries2,
-//					(key, value1, value2) -> {
-//						keys.add(key);
-//						return value2;
-//					});
-//
-//				assert returned == entries1;
-//				assert keys.isEmpty();
-//
-//				assert new Set<>(entries1.store)
-//					.equals(proto);
-//			}
-//		}
-//
-//		@Nested
-//		@DisplayName("when map is empty")
-//		class EmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-//
-//			@Test
-//			@DisplayName("adds all entries")
-//			void addsAllEntries() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<>(
-//					new Map.Entry<>("G", 3),
-//					new Map.Entry<>("e", 7));
-//
-//				final var keys = new MutableSet<String>();
-//				final var returned = entries1.add(entries2,
-//					(key, value1, value2) -> {
-//						keys.add(key);
-//						return value2;
-//					});
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("G", 3),
-//					new Map.Entry<>("e", 7));
-//
-//				assert returned == entries1;
-//				assert keys.isEmpty();
-//
-//				assert new Set<>(entries1.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when argument map is empty, does nothing")
-//			void doesNothingWhenArgMapEmpty() {
-//				final var entries1 = new MutableMap<>(proto);
-//				final var entries2 = new Map<String, Integer>();
-//
-//				final var keys = new MutableSet<String>();
-//				final var returned = entries1.add(entries2,
-//					(key, value1, value2) -> {
-//						keys.add(key);
-//						return value2;
-//					});
-//
-//				assert returned == entries1;
-//				assert keys.isEmpty();
-//
-//				assert new Set<>(entries1.store)
-//					.equals(proto);
-//			}
-//		}
-//	}
-//
-//	@Nested
-//	@DisplayName(".remove(K)")
-//	class RemoveTests {
-//		@Nested
-//		@DisplayName("when map is not empty")
-//		class NotEmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-//				new Map.Entry<>("P", 5),
-//				new Map.Entry<>("l", 4),
-//				new Map.Entry<>("M", 3),
-//				new Map.Entry<>("F", 5));
-//
-//			@Test
-//			@DisplayName("when key is present, removes its entry")
-//			void removesEntryWhenKeyPresent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove("M");
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("P", 5),
-//					new Map.Entry<>("l", 4),
-//					new Map.Entry<>("F", 5));
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when key is absent, does nothing")
-//			void doesNothingWhenKeyAbsent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove("m");
-//
-//				assert returned == entries;
-//				assert entries.store
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when key is null, does nothing")
-//			void doesNothingWhenKeyNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove((String) null);
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//		}
-//
-//		@Nested
-//		@DisplayName("when map is empty")
-//		class EmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-//
-//			@Test
-//			@DisplayName("does nothing")
-//			void doesNothing() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove("b");
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when key is null, does nothing")
-//			void doesNothingWhenKeyNull() {
-//				final var entries = new MutableMap<String, Integer>();
-//				final var returned = entries.remove((String) null);
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//		}
-//	}
-//
-//	@SuppressWarnings("ConstantConditions")
-//	@Nested
-//	@DisplayName(".remove(K...)")
-//	class RemoveVarargsTests {
-//		@Nested
-//		@DisplayName("when map is not empty")
-//		class NotEmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-//				new Map.Entry<>("P", 5),
-//				new Map.Entry<>("l", 4),
-//				new Map.Entry<>("M", 3),
-//				new Map.Entry<>("F", 5));
-//
-//			@Test
-//			@DisplayName("when all keys are present, removes their entries")
-//			void removesEntriesWhenAllKeysPresent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove("M", "P", "F");
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("l", 4));
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when some keys are present, removes their entries")
-//			void removesEntriesWhenSomeKeysPresent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove("M", "p", "F", "L");
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("P", 5),
-//					new Map.Entry<>("l", 4));
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when no keys are present, does nothing")
-//			void doesNothingWhenNoKeysPresent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove("V", "b", "L", "w");
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when some keys are null, ignores them")
-//			void ignoresNullsWhenSomeKeysNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove("m", null, "P", null, null, "F");
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("l", 4),
-//					new Map.Entry<>("M", 3));
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(expected);
-//			}
-//		}
-//
-//		@Nested
-//		@DisplayName("when map is empty")
-//		class EmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-//
-//			@Test
-//			@DisplayName("does nothing")
-//			void doesNothing() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove("b", "F", "w");
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//
-//			@Test
-//			@DisplayName("when some keys are null, does nothing")
-//			void doesNothingWhenSomeKeysNull() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove(null, "V", null, null, "Q");
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//		}
-//	}
-//
-//	@Nested
-//	@DisplayName(".remove(Collection<K>)")
-//	class RemoveCollectionTests {
-//		@Nested
-//		@DisplayName("when map is not empty")
-//		class NotEmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
-//				new Map.Entry<>("P", 5),
-//				new Map.Entry<>("l", 3),
-//				new Map.Entry<>("M", 4),
-//				new Map.Entry<>("F", 5));
-//
-//			@Test
-//			@DisplayName("when all keys are present, removes entries")
-//			void removesEntriesWhenAllKeysPresent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove(
-//					new Set<>("M", "P", "F"));
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("l", 4));
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when some keys are present, removes entries")
-//			void removesEntriesWhenSomeKeysPresent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove(
-//					new Set<>("M", "p", "F", "L"));
-//
-//				final var expected = new Set<>(
-//					new Map.Entry<>("P", 5),
-//					new Map.Entry<>("l", 4));
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(expected);
-//			}
-//
-//			@Test
-//			@DisplayName("when no keys are present, does nothing")
-//			void doesNothingWhenNoKeysPresent() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove(
-//					new Set<>("V", "b", "L", "w"));
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//		}
-//
-//		@Nested
-//		@DisplayName("when map is empty")
-//		class EmptyMapTests {
-//			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
-//
-//			@Test
-//			@DisplayName("does nothing")
-//			void doesNothing() {
-//				final var entries = new MutableMap<>(proto);
-//				final var returned = entries.remove(
-//					new Set<>("b", "F", "w"));
-//
-//				assert returned == entries;
-//				assert new Set<>(entries.store)
-//					.equals(proto);
-//			}
-//		}
-//	}
-//
-//	@Nested
-//	@DisplayName(".clear()")
-//	class ClearTests {
-//		@Test
-//		@DisplayName("when map is not empty, removes all entries")
-//		void removesAllEntriesWhenNotEmpty() {
-//			final var entries = new MutableMap<>(
-//				new Map.Entry<>("v", 5),
-//				new Map.Entry<>("v", 4),
-//				new Map.Entry<>("v", 2),
-//				new Map.Entry<>("v", 7));
-//
-//			final var returned = entries.clear();
-//
-//			assert returned == entries;
-//			assert new Set<>(entries.store)
-//				.isEmpty();
-//		}
-//
-//		@Test
-//		@DisplayName("when map is empty, does nothing")
-//		void doesNothingWhenEmpty() {
-//			final var entries = new MutableMap<>();
-//			final var returned = entries.clear();
-//
-//			assert returned == entries;
-//			assert new Set<>(entries.store)
-//				.isEmpty();
-//		}
-//	}
-//
-//	@Nested
-//	@DisplayName(".toImmutable()")
-//	class ToImmutableTests {
-//		@Test
-//		@DisplayName("when map is not empty, returns immutable copy")
-//		void returnsMapWhenNotEmpty() {
-//			final var proto = new Set<>(
-//				new Map.Entry<>("G", 0),
-//				new Map.Entry<>("x", 3),
-//				new Map.Entry<>("q", 1));
-//
-//			final var entries1 = new MutableMap<>(proto);
-//			final var entries2 = entries1.toImmutable();
-//
-//			assert Map.class == entries2.getClass();
-//			assert new Set<>(entries2.store)
-//				.equals(proto);
-//		}
-//
-//		@Test
-//		@DisplayName("when map is empty, returns empty immutable copy")
-//		void returnsEmptyMapWhenEmpty() {
-//			final var entries1 = new MutableMap<String, Integer>();
-//			final var entries2 = entries1.toImmutable();
-//
-//			assert Map.class == entries2.getClass();
-//			assert new Set<>(entries2.store)
-//				.isEmpty();
-//		}
-//	}
+	@Nested
+	@DisplayName(".get(K, V)")
+	class GetTests {
+		@Nested
+		@DisplayName("when map is not empty")
+		class NotEmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+				new Map.Entry<>("F", 5),
+				new Map.Entry<>("R", 3),
+				new Map.Entry<>("g", 9));
+
+			@Test
+			@DisplayName("when key is present, does not store and returns stored value")
+			void returnsStoredValueWhenKeyPresent() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get("R", 0);
+
+				assert 3 == value;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+
+			@Test
+			@DisplayName("when key is absent, stores and returns argument value")
+			void returnsArgValueWhenKeyAbsent() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get("r", 0);
+
+				final var expected = new MutableSet<>(proto)
+					.add(new Map.Entry<>("r", 0));
+
+				assert 0 == value;
+				assert new Set<>(entries.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when key is present and argument value is null, does not store and returns stored value")
+			void returnsStoredValueWhenKeyPresentArgValueNull() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get("F", null);
+
+				assert 5 == value;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+
+			@Test
+			@DisplayName("when key is absent and argument value is null, does not store and returns null")
+			void returnsNullWhenKeyAbsentArgValueNull() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get("X", null);
+
+				assert null == value;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+
+			@Test
+			@DisplayName("when key is null, does not store but returns argument value")
+			void returnsArgValueWhenKeyNull() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get(null, 9);
+
+				assert 9 == value;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+
+			@Test
+			@DisplayName("when key and argument value are null, does not store and returns null")
+			void returnsNullWhenKeyArgValueNull() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get(null, null);
+
+				assert null == value;
+				assert entries.store
+					.equals(proto.store);
+			}
+		}
+
+		@Nested
+		@DisplayName("when map is empty")
+		class EmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+
+			@Test
+			@DisplayName("stores and returns argument value")
+			void returnsArgValue() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get("F", 3);
+
+				final var expected = new MutableSet<>(proto)
+					.add(new Map.Entry<>("F", 3));
+
+				assert 3 == value;
+				assert new Set<>(entries.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when key is null, does not store but returns argument value")
+			void returnsArgValueWhenKeyNull() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get(null, 9);
+
+				assert 9 == value;
+				assert entries.store
+					.equals(proto.store);
+			}
+
+			@Test
+			@DisplayName("when argument value is null, does not store and returns null")
+			void returnsNullWhenArgValueNull() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get("F", null);
+
+				assert null == value;
+				assert entries.store
+					.equals(proto.store);
+			}
+
+			@Test
+			@DisplayName("when key and argument value are null, does not store and returns null")
+			void returnsNullWhenKeyArgValueNull() {
+				final var entries = new MutableMap<>(proto);
+				final var value = entries.get(null, null);
+
+				assert null == value;
+				assert entries.store
+					.equals(proto.store);
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName(".set(K, V)")
+	class SetTests {
+		private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+			new Map.Entry<>("G", 7),
+			new Map.Entry<>("x", 0));
+
+		@Test
+		@DisplayName("when key is absent, inserts new entry")
+		void insertsEntryWhenKeyAbsent() {
+			final var entries = new MutableMap<>(proto);
+			final var returned = entries.set("B", 4);
+
+			final var expected = new MutableSet<>(proto)
+				.add(new Map.Entry<>("B", 4));
+
+			assert entries == returned;
+			assert new Set<>(entries.store)
+				.equals(expected);
+		}
+
+		@Test
+		@DisplayName("when key already present, replaces stored value")
+		void replacesStoredValueWhenKeyPresent() {
+			final var entries = new MutableMap<>(proto);
+			final var returned = entries.set("x", 4);
+
+			final var expected = new Set<>(
+				new Map.Entry<>("G", 7),
+				new Map.Entry<>("x", 4));
+
+			assert entries == returned;
+			assert new Set<>(entries.store)
+				.equals(expected);
+		}
+
+		@Test
+		@DisplayName("when key is null, does nothing")
+		void doesNothingWhenKeyNull() {
+			final var entries = new MutableMap<>(proto);
+			final var returned = entries.set(null, 4);
+
+			assert entries == returned;
+			assert entries.store
+				.equals(proto.store);
+		}
+
+		@Test
+		@DisplayName("when value is null, does nothing")
+		void doesNothingWhenValueNull() {
+			final var entries = new MutableMap<>(proto);
+			final var returned = entries.set("H", null);
+
+			assert entries == returned;
+			assert entries.store
+				.equals(proto.store);
+		}
+	}
+
+	@Nested
+	@DisplayName(".add(Map<K, V>)")
+	class AddMapTests {
+		@Nested
+		@DisplayName("when map is not empty")
+		class NotEmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+				new Map.Entry<>("B", 0),
+				new Map.Entry<>("J", 9),
+				new Map.Entry<>("s", 4));
+
+			@Test
+			@DisplayName("when all keys are absent, adds entries")
+			void addsEntriesWhenAllKeysAbsent() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<>(
+					new Map.Entry<>("N", 9),
+					new Map.Entry<>("p", 1));
+
+				final var returned = entries1.add(entries2);
+
+				final var expected = new Set<>(
+					new Map.Entry<>("B", 0),
+					new Map.Entry<>("J", 9),
+					new Map.Entry<>("s", 4),
+					new Map.Entry<>("N", 9),
+					new Map.Entry<>("p", 1));
+
+				assert returned == entries1;
+				assert new Set<>(entries1.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when some keys are present, replaces their values")
+			void replacesValuesWhenSomeKeysPresent() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<>(
+					new Map.Entry<>("B", 9),
+					new Map.Entry<>("s", 1));
+
+				final var returned = entries1.add(entries2);
+
+				final var expected = new Set<>(
+					new Map.Entry<>("B", 9),
+					new Map.Entry<>("J", 9),
+					new Map.Entry<>("s", 1));
+
+				assert returned == entries1;
+				assert new Set<>(entries1.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when argument map is empty, does nothing")
+			void doesNothingWhenArgMapEmpty() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<String, Integer>();
+
+				final var returned = entries1.add(entries2);
+
+				assert returned == entries1;
+				assert new Set<>(entries1.store)
+					.equals(proto);
+			}
+		}
+
+		@Nested
+		@DisplayName("when map is empty")
+		class EmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+
+			@Test
+			@DisplayName("adds entries")
+			void addsEntries() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<>(
+					new Map.Entry<>("K", 9),
+					new Map.Entry<>("m", 8));
+
+				final var returned = entries1.add(entries2);
+
+				final var expected = new Set<>(
+					new Map.Entry<>("K", 9),
+					new Map.Entry<>("m", 8));
+
+				assert returned == entries1;
+				assert new Set<>(entries1.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when argument map is empty, does nothing")
+			void doesNothingWhenArgMapEmpty() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<String, Integer>();
+
+				final var returned = entries1.add(entries2);
+
+				assert returned == entries1;
+				assert new Set<>(entries1.store)
+					.isEmpty();
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName(".add(Map<K, V>, BiFunction<V, V, V>)")
+	class AddMapBiFunctionTests {
+		@Nested
+		@DisplayName("when map is not empty")
+		class NotEmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+				new Map.Entry<>("V", 2),
+				new Map.Entry<>("G", 1),
+				new Map.Entry<>("e", 9),
+				new Map.Entry<>("I", 7));
+
+			@Test
+			@DisplayName("when all keys are absent, adds entries")
+			void addsEntriesWhenAllKeysAbsent() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<>(
+					new Map.Entry<>("g", 3),
+					new Map.Entry<>("K", 4));
+
+				final var keys = new MutableSet<String>();
+				final var returned = entries1.add(entries2,
+					(key, value1, value2) -> {
+						keys.add(key);
+						return value2;
+					});
+
+				final var expected = new Set<>(
+					new Map.Entry<>("V", 2),
+					new Map.Entry<>("G", 1),
+					new Map.Entry<>("e", 9),
+					new Map.Entry<>("I", 7),
+					new Map.Entry<>("g", 3),
+					new Map.Entry<>("K", 4));
+
+				assert returned == entries1;
+				assert keys.isEmpty();
+
+				assert new Set<>(entries1.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when some keys are present, resolves their values")
+			void resolvesValuesWhenSomeKeysPresent() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<>(
+					new Map.Entry<>("G", 3),
+					new Map.Entry<>("K", 4),
+					new Map.Entry<>("I", 4));
+
+				final var keys = new MutableSet<String>();
+				final var returned = entries1.add(entries2,
+					(key, value1, value2) -> {
+						keys.add(key);
+						return value2 + 2;
+					});
+
+				final var expected = new Set<>(
+					new Map.Entry<>("V", 2),
+					new Map.Entry<>("G", 5),
+					new Map.Entry<>("e", 9),
+					new Map.Entry<>("I", 6),
+					new Map.Entry<>("K", 4));
+
+				assert returned == entries1;
+				assert new Set<>("G", "I")
+					.equals(keys);
+
+				assert new Set<>(entries1.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when resolver returns null, preserves stored value")
+			void preservesValueWhenResolverReturnsNull() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<>(
+					new Map.Entry<>("G", 3),
+					new Map.Entry<>("K", 4),
+					new Map.Entry<>("I", 4),
+					new Map.Entry<>("e", 7));
+
+				final var keys = new MutableSet<String>();
+				final var returned = entries1.add(entries2,
+					(key, value1, value2) -> {
+						keys.add(key);
+						return value2 > 3 ? null : value2;
+					});
+
+				final var expected = new Set<>(
+					new Map.Entry<>("V", 2),
+					new Map.Entry<>("G", 3),
+					new Map.Entry<>("e", 9),
+					new Map.Entry<>("I", 7),
+					new Map.Entry<>("K", 4));
+
+				assert returned == entries1;
+				assert new Set<>("G", "I", "e")
+					.equals(keys);
+
+				assert new Set<>(entries1.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when argument map is empty, does nothing")
+			void doesNothingWhenArgMapEmpty() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<String, Integer>();
+
+				final var keys = new MutableSet<String>();
+				final var returned = entries1.add(entries2,
+					(key, value1, value2) -> {
+						keys.add(key);
+						return value2;
+					});
+
+				assert returned == entries1;
+				assert keys.isEmpty();
+
+				assert new Set<>(entries1.store)
+					.equals(proto);
+			}
+		}
+
+		@Nested
+		@DisplayName("when map is empty")
+		class EmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+
+			@Test
+			@DisplayName("adds all entries")
+			void addsAllEntries() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<>(
+					new Map.Entry<>("G", 3),
+					new Map.Entry<>("e", 7));
+
+				final var keys = new MutableSet<String>();
+				final var returned = entries1.add(entries2,
+					(key, value1, value2) -> {
+						keys.add(key);
+						return value2;
+					});
+
+				final var expected = new Set<>(
+					new Map.Entry<>("G", 3),
+					new Map.Entry<>("e", 7));
+
+				assert returned == entries1;
+				assert keys.isEmpty();
+
+				assert new Set<>(entries1.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when argument map is empty, does nothing")
+			void doesNothingWhenArgMapEmpty() {
+				final var entries1 = new MutableMap<>(proto);
+				final var entries2 = new Map<String, Integer>();
+
+				final var keys = new MutableSet<String>();
+				final var returned = entries1.add(entries2,
+					(key, value1, value2) -> {
+						keys.add(key);
+						return value2;
+					});
+
+				assert returned == entries1;
+				assert keys.isEmpty();
+
+				assert new Set<>(entries1.store)
+					.equals(proto);
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName(".remove(K)")
+	class RemoveTests {
+		@Nested
+		@DisplayName("when map is not empty")
+		class NotEmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+				new Map.Entry<>("P", 5),
+				new Map.Entry<>("l", 4),
+				new Map.Entry<>("M", 3),
+				new Map.Entry<>("F", 5));
+
+			@Test
+			@DisplayName("when key is present, removes its entry")
+			void removesEntryWhenKeyPresent() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove("M");
+
+				final var expected = new Set<>(
+					new Map.Entry<>("P", 5),
+					new Map.Entry<>("l", 4),
+					new Map.Entry<>("F", 5));
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when key is absent, does nothing")
+			void doesNothingWhenKeyAbsent() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove("m");
+
+				assert returned == entries;
+				assert entries.store
+					.equals(proto.store);
+			}
+
+			@Test
+			@DisplayName("when key is null, does nothing")
+			void doesNothingWhenKeyNull() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove((String) null);
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+		}
+
+		@Nested
+		@DisplayName("when map is empty")
+		class EmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+
+			@Test
+			@DisplayName("does nothing")
+			void doesNothing() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove("b");
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+
+			@Test
+			@DisplayName("when key is null, does nothing")
+			void doesNothingWhenKeyNull() {
+				final var entries = new MutableMap<String, Integer>();
+				final var returned = entries.remove((String) null);
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+		}
+	}
+
+	@SuppressWarnings("ConstantConditions")
+	@Nested
+	@DisplayName(".remove(K...)")
+	class RemoveVarargsTests {
+		@Nested
+		@DisplayName("when map is not empty")
+		class NotEmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+				new Map.Entry<>("P", 5),
+				new Map.Entry<>("l", 4),
+				new Map.Entry<>("M", 3),
+				new Map.Entry<>("F", 5));
+
+			@Test
+			@DisplayName("when all keys are present, removes their entries")
+			void removesEntriesWhenAllKeysPresent() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove("M", "P", "F");
+
+				final var expected = new Set<>(
+					new Map.Entry<>("l", 4));
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when some keys are present, removes their entries")
+			void removesEntriesWhenSomeKeysPresent() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove("M", "p", "F", "L");
+
+				final var expected = new Set<>(
+					new Map.Entry<>("P", 5),
+					new Map.Entry<>("l", 4));
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when no keys are present, does nothing")
+			void doesNothingWhenNoKeysPresent() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove("V", "b", "L", "w");
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+
+			@Test
+			@DisplayName("when some keys are null, ignores them")
+			void ignoresNullsWhenSomeKeysNull() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove("m", null, "P", null, null, "F");
+
+				final var expected = new Set<>(
+					new Map.Entry<>("l", 4),
+					new Map.Entry<>("M", 3));
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(expected);
+			}
+		}
+
+		@Nested
+		@DisplayName("when map is empty")
+		class EmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+
+			@Test
+			@DisplayName("does nothing")
+			void doesNothing() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove("b", "F", "w");
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+
+			@Test
+			@DisplayName("when some keys are null, does nothing")
+			void doesNothingWhenSomeKeysNull() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove(null, "V", null, null, "Q");
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName(".remove(Collection<K>)")
+	class RemoveCollectionTests {
+		@Nested
+		@DisplayName("when map is not empty")
+		class NotEmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>(
+				new Map.Entry<>("P", 5),
+				new Map.Entry<>("l", 3),
+				new Map.Entry<>("M", 4),
+				new Map.Entry<>("F", 5));
+
+			@Test
+			@DisplayName("when all keys are present, removes entries")
+			void removesEntriesWhenAllKeysPresent() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove(
+					new Set<>("M", "P", "F"));
+
+				final var expected = new Set<>(
+					new Map.Entry<>("l", 4));
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when some keys are present, removes entries")
+			void removesEntriesWhenSomeKeysPresent() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove(
+					new Set<>("M", "p", "F", "L"));
+
+				final var expected = new Set<>(
+					new Map.Entry<>("P", 5),
+					new Map.Entry<>("l", 4));
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(expected);
+			}
+
+			@Test
+			@DisplayName("when no keys are present, does nothing")
+			void doesNothingWhenNoKeysPresent() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove(
+					new Set<>("V", "b", "L", "w"));
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+		}
+
+		@Nested
+		@DisplayName("when map is empty")
+		class EmptyMapTests {
+			private final Set<Map.Entry<String, Integer>> proto = new Set<>();
+
+			@Test
+			@DisplayName("does nothing")
+			void doesNothing() {
+				final var entries = new MutableMap<>(proto);
+				final var returned = entries.remove(
+					new Set<>("b", "F", "w"));
+
+				assert returned == entries;
+				assert new Set<>(entries.store)
+					.equals(proto);
+			}
+		}
+	}
+
+	@Nested
+	@DisplayName(".clear()")
+	class ClearTests {
+		@Test
+		@DisplayName("when map is not empty, removes all entries")
+		void removesAllEntriesWhenNotEmpty() {
+			final var entries = new MutableMap<>(
+				new Map.Entry<>("v", 5),
+				new Map.Entry<>("v", 4),
+				new Map.Entry<>("v", 2),
+				new Map.Entry<>("v", 7));
+
+			final var returned = entries.clear();
+
+			assert returned == entries;
+			assert new Set<>(entries.store)
+				.isEmpty();
+		}
+
+		@Test
+		@DisplayName("when map is empty, does nothing")
+		void doesNothingWhenEmpty() {
+			final var entries = new MutableMap<>();
+			final var returned = entries.clear();
+
+			assert returned == entries;
+			assert new Set<>(entries.store)
+				.isEmpty();
+		}
+	}
+
+	@Nested
+	@DisplayName(".toImmutable()")
+	class ToImmutableTests {
+		@Test
+		@DisplayName("when map is not empty, returns immutable copy")
+		void returnsMapWhenNotEmpty() {
+			final var proto = new Set<>(
+				new Map.Entry<>("G", 0),
+				new Map.Entry<>("x", 3),
+				new Map.Entry<>("q", 1));
+
+			final var entries1 = new MutableMap<>(proto);
+			final var entries2 = entries1.toImmutable();
+
+			assert Map.class == entries2.getClass();
+			assert new Set<>(entries2.store)
+				.equals(proto);
+		}
+
+		@Test
+		@DisplayName("when map is empty, returns empty immutable copy")
+		void returnsEmptyMapWhenEmpty() {
+			final var entries1 = new MutableMap<String, Integer>();
+			final var entries2 = entries1.toImmutable();
+
+			assert Map.class == entries2.getClass();
+			assert new Set<>(entries2.store)
+				.isEmpty();
+		}
+	}
 }
 
 // created on Sep 1, 2019

--- a/src/test/java/co/tsyba/core/collections/MutableSetTests.java
+++ b/src/test/java/co/tsyba/core/collections/MutableSetTests.java
@@ -15,6 +15,76 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class MutableSetTests {
+	@DisplayName(".unite(Set<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns a mutable set;" +
+			"[f, r, q, e, a]; [t, w, e, s]"
+	}, delimiter = ';')
+	void testUnite(String name, @StringMutableSet MutableSet<String> items1,
+		@StringMutableSet MutableSet<String> items2) {
+
+		final var returned = items1.unite(items2);
+		final var klass = returned.getClass();
+		assertEquals(MutableSet.class, klass);
+	}
+
+	@DisplayName(".intersect(Set<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns a mutable set;" +
+			"[f, r, q, e, a]; [t, w, e, s]"
+	}, delimiter = ';')
+	void testIntersect(String name, @StringMutableSet MutableSet<String> items1,
+		@StringMutableSet MutableSet<String> items2) {
+
+		final var returned = items1.intersect(items2);
+		final var klass = returned.getClass();
+		assertEquals(MutableSet.class, klass);
+	}
+
+	@DisplayName(".subtract(Set<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns a mutable set;" +
+			"[f, r, q, e, a]; [t, w, e, s]"
+	}, delimiter = ';')
+	void testSubtract(String name, @StringMutableSet MutableSet<String> items1,
+		@StringMutableSet MutableSet<String> items2) {
+
+		final var returned = items1.subtract(items2);
+		final var klass = returned.getClass();
+		assertEquals(MutableSet.class, klass);
+	}
+
+	@DisplayName(".symmetricSubtract(Set<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns a mutable set;" +
+			"[f, r, q, e, a]; [t, w, e, s]"
+	}, delimiter = ';')
+	void testSymmetricSubtract(String name, @StringMutableSet MutableSet<String> items1,
+		@StringMutableSet MutableSet<String> items2) {
+
+		final var returned = items1.symmetricSubtract(items2);
+		final var klass = returned.getClass();
+		assertEquals(MutableSet.class, klass);
+	}
+
+	@DisplayName(".multiply(Set<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns a mutable set;" +
+			"[f, r, q, e, a]; [t, w, e, s]"
+	}, delimiter = ';')
+	void testMultiply(String name, @StringMutableSet MutableSet<String> items1,
+		@StringMutableSet MutableSet<String> items2) {
+
+		final var returned = items1.multiply(items2);
+		final var klass = returned.getClass();
+		assertEquals(MutableSet.class, klass);
+	}
+
 	@DisplayName(".add(T)")
 	@ParameterizedTest(name = "{0}")
 	@CsvSource(value = {
@@ -327,6 +397,42 @@ public class MutableSetTests {
 
 		assertSame(items, returned);
 		assertEquals(expected, items);
+	}
+
+	@DisplayName(".iterate(Consumer<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns itself;" +
+			"[f, r, q, e, a]"
+	}, delimiter = ';')
+	void testIterate(String name, @StringMutableSet MutableSet<String> items) {
+		@SuppressWarnings("ResultOfMethodCallIgnored")
+		final var returned = items.iterate(String::toLowerCase);
+		assertSame(items, returned);
+	}
+
+	@DisplayName(".filter(Predicate<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns a mutable set;" +
+			"[f, r, q, e, a]"
+	}, delimiter = ';')
+	void testFilter(String name, @StringMutableSet MutableSet<String> items) {
+		final var returned = items.filter(String::isBlank);
+		final var klass = returned.getClass();
+		assertEquals(MutableSet.class, klass);
+	}
+
+	@DisplayName(".convert(Function<T, R>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns a mutable set;" +
+			"[f, r, q, e, a]"
+	}, delimiter = ';')
+	void testConvert(String name, @StringMutableSet MutableSet<String> items) {
+		final var returned = items.convert(String::toLowerCase);
+		final var klass = returned.getClass();
+		assertEquals(MutableSet.class, klass);
 	}
 
 	@DisplayName(".toImmutable()")

--- a/src/test/java/co/tsyba/core/collections/MutableSetTests.java
+++ b/src/test/java/co/tsyba/core/collections/MutableSetTests.java
@@ -1,554 +1,366 @@
 package co.tsyba.core.collections;
 
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.converter.TypedArgumentConverter;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import java.util.ArrayList;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
 public class MutableSetTests {
-	@Nested
 	@DisplayName(".add(T)")
-	class AddTests {
-		@Test
-		@DisplayName("adds item")
-		void addsItem() {
-			final var items = new MutableSet<>("g", "Q", "h");
-			final var returned = items.add("B");
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when item is absent, adds item;" +
+			"[g, e, Q, s, A, m]; P;" +
+			"[g, e, Q, s, A, m, P]",
+		"when item is present, does not add item;" +
+			"[g, e, Q, s, A, m]; Q;" +
+			"[g, e, Q, s, A, m]",
+		"when item is null, does nothing;" +
+			"[b, M, L, s, P]; null;" +
+			"[b, M, L, s, P]",
+		"when set is empty and item is not null, adds item;" +
+			"[]; V;" +
+			"[V]",
+		"when set is empty and item is null, does not add item;" +
+			"[]; null;" +
+			"[]"
+	}, delimiter = ';', nullValues = "null")
+	void testAdd(String name, @StringMutableSet MutableSet<String> items,
+		String item, @StringSet Set<String> expected) {
 
-			assert returned == items;
-			assert new Set<>("g", "Q", "h", "B")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("does not add duplicate item")
-		void doesNotAddDuplicate() {
-			final var items = new MutableSet<>("g", "Q", "h");
-			final var returned = items.add("Q");
-
-			assert returned == items;
-			assert new Set<>("g", "Q", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("does not add null item")
-		void doesNotAddNull() {
-			final var items = new MutableSet<>("g", "Q", "h");
-			final var returned = items.add((String) null);
-
-			assert returned == items;
-			assert new Set<>("g", "Q", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("adds first item")
-		void addsFirstItem() {
-			final var items = new MutableSet<>();
-			final var returned = items.add("Q");
-
-			assert returned == items;
-			assert new Set<>("Q")
-				.equals(items);
-		}
+		final var returned = items.add(item);
+		assertSame(items, returned);
+		assertEquals(expected, items);
 	}
 
-	@Nested
 	@DisplayName(".add(T...)")
-	class AddVarargsTests {
-		@Test
-		@DisplayName("adds items")
-		void addsItems() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add("m", "Q", "k");
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when all items are absent, adds items;" +
+			"[b, L, s, W]; [e, Q, o];" +
+			"[b, L, s, W, e, Q, o]",
+		"when some items are present, adds absent items;" +
+			"[b, L, s, W]; [b, E, s, W, l];" +
+			"[b, L, s, W, E, l]",
+		"when all items are present, does not add items;" +
+			"[b, L, s, W]; [b, E, s, W, l];" +
+			"[b, L, s, W, E, l]",
+		"when some items are null, adds non-null items;" +
+			"[b, L, s, W]; [null, R, null, null, K];" +
+			"[b, L, s, W, R, K]",
+		"when all items are null, does nothing;" +
+			"[b, L, s, W]; [null, null];" +
+			"[b, L, s, W]",
+		"when items are empty, does nothing;" +
+			"[b, L, s, W]; [];" +
+			"[b, L, s, W]",
+		"when set is empty and all items are not null, adds items;" +
+			"[]; [g, O, p, R];" +
+			"[g, O, p, R]",
+		"when set is empty and some items are null, adds non-null items;" +
+			"[]; [b, null, P, k, null];" +
+			"[b, P, k]",
+		"when set is empty and all items are null, does nothing;" +
+			"[]; [null, null, null, null];" +
+			"[]",
+		"when set and items are empty, does nothing;" +
+			"[]; [];" +
+			"[]"
+	}, delimiter = ';', nullValues = "null")
+	void testAddVarargs(String name, @StringMutableSet MutableSet<String> items1,
+		@StringArray String[] items2, @StringSet Set<String> expected) {
 
-			assert returned == items;
-			assert new Set<>("g", "b", "K", "m", "Q", "k")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("does not add duplicates")
-		void doesNotAddDuplicates() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add("K", "Q", "b");
-
-			assert returned == items;
-			assert new Set<>("g", "b", "K", "Q")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("does not add nulls")
-		void doesNotAddNulls() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add(null, "a", null, null);
-
-			assert returned == items;
-			assert new Set<>("g", "b", "K", "a")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("adds first items")
-		void addsFirstItems() {
-			final var items = new MutableSet<>();
-			final var returned = items.add("m", "Q", "K");
-
-			assert returned == items;
-			assert new Set<>("m", "Q", "K")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when items are empty, does nothing")
-		void doesNotAddEmptyItems() {
-			final var items = new MutableSet<>("m", "Q", "K");
-			final var returned = items.add();
-
-			assert returned == items;
-			assert new Set<>("m", "Q", "K")
-				.equals(items);
-		}
+		final var returned = items1.add(items2);
+		assertSame(items1, returned);
+		assertEquals(expected, items1);
 	}
 
-	@Nested
 	@DisplayName(".add(Collection<T>)")
-	class AddCollectionTests {
-		@Test
-		@DisplayName("adds items")
-		void addsItems() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add(
-				new List<>("m", "Q", "k"));
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when all items are absent, adds items;" +
+			"[j, I, w, 9, 7]; [l, k, O];" +
+			"[j, I, w, 9, 7, l, k, O]",
+		"when some items are present, adds absent items;" +
+			"[j, I, w, 9, 7]; [l, 9, I];" +
+			"[j, I, w, 9, 7, l]",
+		"when all items are present, does not add items;" +
+			"[j, I, w, 9, 7]; [j, I, w, 9, 7];" +
+			"[j, I, w, 9, 7]",
+		"when items are empty, does nothing;" +
+			"[k, m, H, u, 7, h]; [];" +
+			"[k, m, H, u, 7, h]",
+		"when set is empty, adds items;" +
+			"[]; [j, I, w, 9, 7];" +
+			"[j, I, w, 9, 7]",
+		"when set and items are empty, does nothing;" +
+			"[]; [];" +
+			"[]"
+	}, delimiter = ';')
+	void testAddCollection(String name, @StringMutableSet MutableSet<String> items1,
+		@StringCollection Collection<String> items2, @StringSet Set<String> expected) {
 
-			assert returned == items;
-			assert new Set<>("g", "b", "K", "m", "Q", "k")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("does not add duplicates")
-		void doesNotAddDuplicates() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add(
-				new List<>("K", "Q", "b"));
-
-			assert returned == items;
-			assert new Set<>("g", "b", "K", "Q")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("adds first items")
-		void addsFirstItems() {
-			final var items = new MutableSet<String>();
-			final var returned = items.add(
-				new List<>("m", "Q", "K"));
-
-			assert returned == items;
-			assert new Set<>("m", "Q", "K")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when items are empty, does nothing")
-		void doesNotAddEmptyItems() {
-			final var items = new MutableSet<>("m", "Q", "K");
-			final var returned = items.add(
-				new List<>());
-
-			assert returned == items;
-			assert new Set<>("m", "Q", "K")
-				.equals(items);
-		}
+		final var returned = items1.add(items2);
+		assertSame(items1, returned);
+		assertEquals(expected, items1);
 	}
 
-	@Nested
 	@DisplayName(".add(Iterable<T>)")
-	class AddIterableTests {
-		@Test
-		@DisplayName("adds items")
-		void addsItems() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add(
-				Arrays.asList("m", "Q", "k"));
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when all items are absent, adds items;" +
+			"[b, L, s, W]; [e, Q, o];" +
+			"[b, L, s, W, e, Q, o]",
+		"when some items are present, adds absent items;" +
+			"[b, L, s, W]; [b, E, s, W, l];" +
+			"[b, L, s, W, E, l]",
+		"when all items are present, does not add items;" +
+			"[b, L, s, W]; [b, E, s, W, l];" +
+			"[b, L, s, W, E, l]",
+		"when some items are null, adds non-null items;" +
+			"[b, L, s, W]; [null, R, null, null, K];" +
+			"[b, L, s, W, R, K]",
+		"when all items are null, does nothing;" +
+			"[b, L, s, W]; [null, null];" +
+			"[b, L, s, W]",
+		"when items are empty, does nothing;" +
+			"[b, L, s, W]; [];" +
+			"[b, L, s, W]",
+		"when set is empty and all items are not null, adds items;" +
+			"[]; [g, O, p, R];" +
+			"[g, O, p, R]",
+		"when set is empty and some items are null, adds non-null items;" +
+			"[]; [b, null, P, k, null];" +
+			"[b, P, k]",
+		"when set is empty and all items are null, does nothing;" +
+			"[]; [null, null, null, null];" +
+			"[]",
+		"when set and items are empty, does nothing;" +
+			"[]; [];" +
+			"[]"
+	}, delimiter = ';', nullValues = "null")
+	void testAddIterable(String name, @StringMutableSet MutableSet<String> items1,
+		@StringArray String[] items2, @StringSet Set<String> expected) {
 
-			assert returned == items;
-			assert new Set<>("g", "b", "K", "m", "Q", "k")
-				.equals(items);
-		}
+		final var items3 = Arrays.asList(items2);
+		final var returned = items1.add(items3);
 
-		@Test
-		@DisplayName("does not add duplicates")
-		void doesNotAddDuplicates() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add(
-				Arrays.asList("K", "Q", "b"));
-
-			assert returned == items;
-			assert new Set<>("g", "b", "K", "Q")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("does not add nulls")
-		void doesNotAddNulls() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add(
-				Arrays.asList(null, "a", null, null));
-
-			assert returned == items;
-			assert new Set<>("g", "b", "K", "a")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("adds first items")
-		void addsFirstItems() {
-			final var items = new MutableSet<>();
-			final var returned = items.add(
-				Arrays.asList("m", "Q", "K"));
-
-			assert returned == items;
-			assert new Set<>("m", "Q", "K")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when items are empty, does nothing")
-		void doesNotAddEmptyItems() {
-			final var items = new MutableSet<>("g", "b", "K");
-			final var returned = items.add(
-				new List<>());
-
-			assert returned == items;
-			assert new Set<>("g", "b", "K")
-				.equals(items);
-		}
+		assertSame(items1, returned);
+		assertEquals(expected, items1);
 	}
 
-	@Nested
 	@DisplayName(".remove(T)")
-	class RemoveTests {
-		@Test
-		@DisplayName("when item is present, removes item")
-		void removesItemWhenPresent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove("2");
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when item is present, removes item;" +
+			"[g, O, e, T, d, f, l]; T;" +
+			"[g, O, e, d, f, l]",
+		"when item is present and is the only item, removes item;" +
+			"[g]; g;" +
+			"[]",
+		"when item is absent, does not remove item;" +
+			"[g, O, e, T, d, f, l]; t;" +
+			"[g, O, e, T, d, f, l]",
+		"when item is null, does nothing;" +
+			"[g, O, e, T, d, f, l]; null;" +
+			"[g, O, e, T, d, f, l]",
+		"when set is empty and item is not null, does nothing;" +
+			"[]; T;" +
+			"[]",
+		"when set is empty and item is null, does nothing;" +
+			"[]; null;" +
+			"[]"
+	}, delimiter = ';', nullValues = "null")
+	void testRemove(String name, @StringMutableSet MutableSet<String> items,
+		String item, @StringSet Set<String> expected) {
 
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when item is absent, does nothing")
-		void doesNothingWhenAbsent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove("7");
-
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "2", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when item is absent, does nothing")
-		void doesNothingWhenItemNull() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove("7");
-
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "2", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when item is present and is last item, removes item")
-		void removesLastItemWhenPresent() {
-			final var items = new MutableSet<>("7");
-			final var returned = items.remove("7");
-
-			assert returned == items;
-			assert new Set<String>()
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when set is empty, does nothing")
-		void doesNothingWhenEmpty() {
-			final var items = new MutableSet<String>();
-			final var returned = items.remove("7");
-
-			assert returned == items;
-			assert new Set<String>()
-				.equals(items);
-		}
+		final var returned = items.remove(item);
+		assertSame(items, returned);
+		assertEquals(expected, items);
 	}
 
-	@Nested
 	@DisplayName(".remove(T...)")
-	class RemoveVarargsTests {
-		@Test
-		@DisplayName("when some items are present, removes present items")
-		void removesItemsWhenSomePresent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove("h", "q", "1", "B");
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when all items are present, removes items;" +
+			"[n, M, m, L, I, o, p]; [M, L, I];" +
+			"[n, m, o, p]",
+		"when all items are present and are the only items, removes all items;" +
+			"[n, M, m, L, I, o, p]; [n, M, m, L, I, o, p];" +
+			"[]",
+		"when some items are present, removes present items;" +
+			"[n, M, m, L, I, o, p]; [U, L, N, p];" +
+			"[n, M, m, I, o]",
+		"when all items are absent, does nothing;" +
+			"[n, M, m, L, I, o, p]; [U, P, O, N];" +
+			"[n, M, m, L, I, o, p]",
+		"when some items are null, removes non-null items;" +
+			"[n, M, m, L, I, o, p]; [n, null, M, null, null, p];" +
+			"[m, L, I, o]",
+		"when all items are null, does nothing;" +
+			"[n, M, m, L, I, o, p]; [null, null];" +
+			"[n, M, m, L, I, o, p]",
+		"when items are empty, does nothing;" +
+			"[n, M, m, L, I, o, p]; [];" +
+			"[n, M, m, L, I, o, p]",
+		"when set is empty and all items are not null, does nothing;" +
+			"[]; [M, I, O, P];" +
+			"[]",
+		"when set is empty and some items are null, does nothing;" +
+			"[]; [null, null, P, null];" +
+			"[]",
+		"when set is empty and all items are null, does nothing;" +
+			"[]; [null, null];" +
+			"[]",
+		"when set and items are empty, does nothing;" +
+			"[]; [];" +
+			"[]"
+	}, delimiter = ';', nullValues = "null")
+	void testRemoveVarargs(String name, @StringMutableSet MutableSet<String> items1,
+		@StringArray String[] items2, @StringSet Set<String> expected) {
 
-			assert returned == items;
-			assert new Set<>("Q", "2")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when all items are present, removes all items")
-		void removesItemsWhenAllPresent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove("B", "Q", "1", "2", "h");
-
-			assert returned == items;
-			assert new Set<>()
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when all items are absent, does nothing")
-		void doesNothingWhenAllAbsent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove("7", "4", "G", "b");
-
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "2", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when some items are null, removes non-null items")
-		void ignoresNullItems() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(null, "Q", null, "2");
-
-			assert returned == items;
-			assert new Set<>("B", "1", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when items are empty, does nothing")
-		void doesNothingWhenItemsEmpty() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove();
-
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "2", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when set is empty, does nothing")
-		void doesNothingWhenEmpty() {
-			final var items = new MutableSet<String>();
-			final var returned = items.remove("B", "Q", "1", "2", "h");
-
-			assert returned == items;
-			assert new Set<String>()
-				.equals(items);
-		}
+		final var returned = items1.remove(items2);
+		assertSame(items1, returned);
+		assertEquals(expected, items1);
 	}
 
-	@Nested
 	@DisplayName(".remove(Collection<T>)")
-	class RemoveCollectionTests {
-		@Test
-		@DisplayName("when some items are present, removes present items")
-		void removesItemsWhenSomePresent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				new List<>("h", "q", "1", "B"));
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when all items are present, removes items;" +
+			"[n, M, m, L, I, o, p]; [M, L, I];" +
+			"[n, m, o, p]",
+		"when all items are present and are the only items, removes all items;" +
+			"[n, M, m, L, I, o, p]; [n, M, m, L, I, o, p];" +
+			"[]",
+		"when some items are present, removes present items;" +
+			"[n, M, m, L, I, o, p]; [U, L, N, p];" +
+			"[n, M, m, I, o]",
+		"when all items are absent, does nothing;" +
+			"[n, M, m, L, I, o, p]; [U, P, O, N];" +
+			"[n, M, m, L, I, o, p]",
+		"when items are empty, does nothing;" +
+			"[n, M, m, L, I, o, p]; [];" +
+			"[n, M, m, L, I, o, p]",
+		"when set is empty, does nothing;" +
+			"[]; [M, I, O, P];" +
+			"[]",
+		"when set and items are empty, does nothing;" +
+			"[]; [];" +
+			"[]"
+	}, delimiter = ';')
+	void testRemoveCollection(String name, @StringMutableSet MutableSet<String> items1,
+		@StringCollection Collection<String> items2, @StringSet Set<String> expected) {
 
-			assert returned == items;
-			assert new Set<>("Q", "2")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when all items are present, removes all items")
-		void removesItemsWhenAllPresent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				new List<>("B", "Q", "1", "2", "h"));
-
-			assert returned == items;
-			assert new Set<>()
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when all items are absent, does nothing")
-		void doesNothingWhenAllAbsent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				new List<>("7", "4", "G", "b"));
-
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "2", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when items are empty, does nothing")
-		void doesNothingWhenItemsEmpty() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				new List<>());
-
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "2", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when set is empty, does nothing")
-		void doesNothingWhenEmpty() {
-			final var items = new MutableSet<String>();
-			final var returned = items.remove(
-				new List<>("B", "Q", "1", "2", "h"));
-
-			assert returned == items;
-			assert new Set<String>()
-				.equals(items);
-		}
+		final var returned = items1.remove(items2);
+		assertSame(items1, returned);
+		assertEquals(expected, items1);
 	}
 
-	@Nested
 	@DisplayName(".remove(Iterable<T>)")
-	class RemoveIterableTests {
-		@Test
-		@DisplayName("when some items are present, removes present items")
-		void removesItemsWhenSomePresent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				Arrays.asList("h", "q", "1", "B"));
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when all items are present, removes items;" +
+			"[n, M, m, L, I, o, p]; [M, L, I];" +
+			"[n, m, o, p]",
+		"when all items are present and are the only items, removes all items;" +
+			"[n, M, m, L, I, o, p]; [n, M, m, L, I, o, p];" +
+			"[]",
+		"when some items are present, removes present items;" +
+			"[n, M, m, L, I, o, p]; [U, L, N, p];" +
+			"[n, M, m, I, o]",
+		"when all items are absent, does nothing;" +
+			"[n, M, m, L, I, o, p]; [U, P, O, N];" +
+			"[n, M, m, L, I, o, p]",
+		"when some items are null, removes non-null items;" +
+			"[n, M, m, L, I, o, p]; [n, null, M, null, null, p];" +
+			"[m, L, I, o]",
+		"when all items are null, does nothing;" +
+			"[n, M, m, L, I, o, p]; [null, null];" +
+			"[n, M, m, L, I, o, p]",
+		"when items are empty, does nothing;" +
+			"[n, M, m, L, I, o, p]; [];" +
+			"[n, M, m, L, I, o, p]",
+		"when set is empty and all items are not null, does nothing;" +
+			"[]; [M, I, O, P];" +
+			"[]",
+		"when set is empty and some items are null, does nothing;" +
+			"[]; [null, null, P, null];" +
+			"[]",
+		"when set is empty and all items are null, does nothing;" +
+			"[]; [null, null];" +
+			"[]",
+		"when set and items are empty, does nothing;" +
+			"[]; [];" +
+			"[]"
+	}, delimiter = ';', nullValues = "null")
+	void testRemoveIterable(String name, @StringMutableSet MutableSet<String> items1,
+		@StringArray String[] items2, @StringSet Set<String> expected) {
 
-			assert returned == items;
-			assert new Set<>("Q", "2")
-				.equals(items);
-		}
+		final var items3 = Arrays.asList(items2);
+		final var returned = items1.remove(items3);
 
-		@Test
-		@DisplayName("when all items are present, removes all items")
-		void removesItemsWhenAllPresent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				Arrays.asList("B", "Q", "1", "2", "h"));
-
-			assert returned == items;
-			assert new Set<>()
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when all items are absent, does nothing")
-		void doesNothingWhenAllAbsent() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				Arrays.asList("7", "4", "G", "b"));
-
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "2", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when some items are null, removes non-null items")
-		void ignoresNullItems() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				Arrays.asList(null, "Q", null, "2"));
-
-			assert returned == items;
-			assert new Set<>("B", "1", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when items are empty, does nothing")
-		void doesNothingWhenItemsEmpty() {
-			final var items = new MutableSet<>("B", "Q", "1", "2", "h");
-			final var returned = items.remove(
-				new ArrayList<>());
-
-			assert returned == items;
-			assert new Set<>("B", "Q", "1", "2", "h")
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when set is empty, does nothing")
-		void doesNothingWhenEmpty() {
-			final var items = new MutableSet<String>();
-			final var returned = items.remove(
-				Arrays.asList("B", "Q", "1", "2", "h"));
-
-			assert returned == items;
-			assert new Set<String>()
-				.equals(items);
-		}
+		assertSame(items1, returned);
+		assertEquals(expected, items1);
 	}
 
-	@Nested
 	@DisplayName(".removeAll()")
-	class RemoveAllTests {
-		@Test
-		@DisplayName("when set is not empty, removes all items")
-		void removesAllItemsWhenNotEmpty() {
-			final var items = new MutableSet<>("h", "b", "n", "m");
-			final var returned = items.removeAll();
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when set is not empty, removes all items;" +
+			"[t, K, L, s, B]",
+		"when set is empty, does nothing;" +
+			"[]"
+	}, delimiter = ';')
+	void testRemoveAll(String name, @StringMutableSet MutableSet<String> items) {
+		final var returned = items.removeAll();
+		final var expected = new Set<String>();
 
-			assert returned == items;
-			assert new Set<String>()
-				.equals(items);
-		}
-
-		@Test
-		@DisplayName("when set is empty, does nothing")
-		void doesNothingWhenEmpty() {
-			final var items = new MutableSet<String>();
-			final var returned = items.removeAll();
-
-			assert returned == items;
-			assert new Set<String>()
-				.equals(items);
-		}
+		assertSame(items, returned);
+		assertEquals(expected, items);
 	}
 
-	@Nested
 	@DisplayName(".toImmutable()")
-	class ToImmutableTests {
-		@Test
-		@DisplayName("when set is not empty, returns immutable set")
-		void removesAllItemsWhenNotEmpty() {
-			final var items1 = new MutableSet<>("h", "b", "n", "m");
-			final var items2 = items1.toImmutable();
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"when set is not empty, returns items in co.tsyba.core.Set;" +
+			"[g, R, e, A, s]",
+		"when set is empty, returns empty co.tsyba.core.Set;" +
+			"[]"
+	}, delimiter = ';')
+	void testToImmutable(String name, @StringMutableSet MutableSet<String> items) {
+		final var immutable = items.toImmutable();
+		final var klass = immutable.getClass();
 
-			assert Set.class == items2.getClass();
-			assert new Set<>("h", "b", "n", "m")
-				.equals(items2);
+		assertEquals(Set.class, klass);
+		assertEquals(items, immutable);
+	}
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConvertWith(StringMutableSet.Converter.class)
+@interface StringMutableSet {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, MutableSet> {
+		protected Converter() {
+			super(String.class, MutableSet.class);
 		}
 
-		@Test
-		@DisplayName("when set is empty, returns empty immutable set")
-		void doesNothingWhenEmpty() {
-			final var items1 = new MutableSet<>();
-			final var items2 = items1.toImmutable();
+		@Override
+		protected MutableSet<String> convert(String s) throws ArgumentConversionException {
+			final var items = new StringArray.Converter()
+				.convert(s);
 
-			assert Set.class == items2.getClass();
-			assert new Set<>()
-				.equals(items2);
+			return new MutableSet<>(items);
 		}
 	}
 }

--- a/src/test/java/co/tsyba/core/collections/SetTests.java
+++ b/src/test/java/co/tsyba/core/collections/SetTests.java
@@ -16,14 +16,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SetTests {
 	@DisplayName("Set(Collection<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when items are not empty, creates set;" +
 			"[g, R, 2, q, P, s];" +
 			"[g, R, 2, q, P, s]",
 		"when items are empty, creates empty set;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testNewCollection(String name, @StringArray String[] items,
 		@StringSet Set<String> expected) {
 
@@ -35,8 +35,8 @@ public class SetTests {
 
 	@DisplayName("Set(T...)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
-		"when no items are null, creates set;" +
+	@CsvSource(value = {
+		"when all items are not null, creates set;" +
 			"[g, R, l, q, P, s, n];" +
 			"[g, R, l, q, P, s, n]",
 		"when some items are null, creates set with non-null items;" +
@@ -48,7 +48,7 @@ public class SetTests {
 		"when items are empty, creates empty set;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testNewVarargs(String name, @StringArray String[] items,
 		@StringSet Set<String> expected) {
 
@@ -58,8 +58,8 @@ public class SetTests {
 
 	@DisplayName("Set(Iterable<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
-		"when no items are null, creates set;" +
+	@CsvSource(value = {
+		"when all items are not null, creates set;" +
 			"[t, y, O, f, A, s];" +
 			"[t, y, O, f, A, s]",
 		"when some items are null, creates set with non-null items;" +
@@ -71,7 +71,7 @@ public class SetTests {
 		"when items are empty, creates empty set;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testNewIterable(String name, @StringArray String[] items,
 		@StringSet Set<String> expected) {
 
@@ -83,14 +83,14 @@ public class SetTests {
 
 	@DisplayName(".getCount()")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when set is not empty, returns item count;" +
 			"[g, b, L, f, s, O, k];" +
 			"7",
 		"when set is empty, returns 0;" +
 			"[];" +
 			"0"
-	})
+	}, delimiter = ';')
 	void testGetCount(String name, @StringSet Set<String> items, int expected) {
 		final var count = items.getCount();
 		assertEquals(expected, count);
@@ -98,7 +98,7 @@ public class SetTests {
 
 	@DisplayName(".contains(T)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when item is present, returns true;" +
 			"[b, K, s, L, m, s, D]; m;" +
 			"true",
@@ -111,7 +111,7 @@ public class SetTests {
 		"when set is empty, returns false;" +
 			"[]; m;" +
 			"false",
-	})
+	}, delimiter = ';')
 	void testContains(String name, @StringSet Set<String> items, String item,
 		boolean expected) {
 
@@ -121,7 +121,7 @@ public class SetTests {
 
 	@DisplayName(".isDisjoint(Set<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when sets are disjoint, returns true;" +
 			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
 			"true",
@@ -131,16 +131,16 @@ public class SetTests {
 		"when sets are equal, returns false;" +
 			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
 			"false",
-		"when set is empty, returns true;" +
-			"[]; [P, z, E, q];" +
-			"true",
 		"when argument set is empty, returns true;" +
 			"[t, E, q, v, b, 0]; [];" +
 			"true",
-		"when both sets are empty, returns true;" +
+		"when set is empty, returns true;" +
+			"[]; [P, z, E, q];" +
+			"true",
+		"when both set and argument set are empty, returns true;" +
 			"[]; [];" +
 			"true"
-	})
+	}, delimiter = ';')
 	void testIsDisjoint(String name, @StringSet Set<String> items1,
 		@StringSet Set<String> items2, boolean expected) {
 
@@ -150,7 +150,7 @@ public class SetTests {
 
 	@DisplayName(".unite(Set<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when sets are disjoint, returns union set;" +
 			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
 			"[t, E, q, v, b, 0, e, g, 7, T]",
@@ -160,16 +160,16 @@ public class SetTests {
 		"when sets are equal, returns union set;" +
 			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
 			"[t, E, q, v, b, 0]",
-		"when set is empty, returns union set;" +
-			"[]; [P, z, E, q];" +
-			"[P, z, E, q]",
 		"when argument set is empty, returns union set;" +
 			"[t, E, q, v, b, 0]; [];" +
 			"[t, E, q, v, b, 0]",
-		"when both sets are empty, returns empty set;" +
+		"when set is empty, returns union set;" +
+			"[]; [P, z, E, q];" +
+			"[P, z, E, q]",
+		"when both set and argument set are empty, returns empty set;" +
 			"[]; [];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testUnite(String name, @StringSet Set<String> items1,
 		@StringSet Set<String> items2, @StringSet Set<String> expected) {
 
@@ -179,7 +179,7 @@ public class SetTests {
 
 	@DisplayName(".intersects(Set<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when sets are disjoint, returns false;" +
 			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
 			"false",
@@ -189,16 +189,16 @@ public class SetTests {
 		"when sets are equal, returns true;" +
 			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
 			"true",
-		"when set is empty, returns false;" +
-			"[]; [P, z, E, q];" +
-			"false",
 		"when argument set is empty, returns false;" +
 			"[t, E, q, v, b, 0]; [];" +
 			"false",
-		"when both sets are empty, returns false;" +
+		"when set is empty, returns false;" +
+			"[]; [P, z, E, q];" +
+			"false",
+		"when both set and argument set are empty, returns false;" +
 			"[]; [];" +
 			"false"
-	})
+	}, delimiter = ';')
 	void testIntersects(String name, @StringSet Set<String> items1,
 		@StringSet Set<String> items2, boolean expected) {
 
@@ -208,7 +208,7 @@ public class SetTests {
 
 	@DisplayName(".intersect(Set<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when sets are disjoint, returns empty set;" +
 			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
 			"[]",
@@ -218,16 +218,16 @@ public class SetTests {
 		"when sets are equal, returns intersection set;" +
 			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
 			"[t, E, q, v, b, 0]",
-		"when set is empty, returns empty set;" +
-			"[]; [P, z, E, q];" +
-			"[]",
 		"when argument set is empty, returns empty set;" +
 			"[t, E, q, v, b, 0]; [];" +
 			"[]",
-		"when both sets are empty, returns empty set;" +
+		"when set is empty, returns empty set;" +
+			"[]; [P, z, E, q];" +
+			"[]",
+		"when both set and argument set are empty, returns empty set;" +
 			"[]; [];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testIntersect(String name, @StringSet Set<String> items1,
 		@StringSet Set<String> items2, @StringSet Set<String> expected) {
 
@@ -237,7 +237,7 @@ public class SetTests {
 
 	@DisplayName(".subtract(Set<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when sets are disjoint, returns difference set;" +
 			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
 			"[t, E, q, v, b, 0]",
@@ -247,16 +247,16 @@ public class SetTests {
 		"when sets are equal, returns empty set;" +
 			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
 			"[]",
-		"when set is empty, returns empty set;" +
-			"[]; [P, z, E, q];" +
-			"[]",
 		"when argument set is empty, returns difference set;" +
 			"[t, E, q, v, b, 0]; [];" +
 			"[t, E, q, v, b, 0]",
-		"when both sets are empty, returns empty set;" +
+		"when set is empty, returns empty set;" +
+			"[]; [P, z, E, q];" +
+			"[]",
+		"when both set and argument set are empty, returns empty set;" +
 			"[]; [];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testSubtract(String name, @StringSet Set<String> items1,
 		@StringSet Set<String> items2, @StringSet Set<String> expected) {
 
@@ -266,7 +266,7 @@ public class SetTests {
 
 	@DisplayName(".symmetricSubtract(Set<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when sets are disjoint, returns symmetric difference set;" +
 			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
 			"[t, E, q, v, b, 0, e, g, 7, T]",
@@ -276,16 +276,16 @@ public class SetTests {
 		"when sets are equal, returns empty set;" +
 			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
 			"[]",
-		"when set is empty, returns symmetric difference set;" +
-			"[]; [P, z, E, q];" +
-			"[P, z, E, q]",
 		"when argument set is empty, returns symmetric difference set;" +
 			"[t, E, q, v, b, 0]; [];" +
 			"[t, E, q, v, b, 0]",
-		"when both sets are empty, returns empty set;" +
+		"when set is empty, returns symmetric difference set;" +
+			"[]; [P, z, E, q];" +
+			"[P, z, E, q]",
+		"when both set and argument set are empty, returns empty set;" +
 			"[]; [];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testSymmetricSubtract(String name, @StringSet Set<String> items1,
 		@StringSet Set<String> items2, @StringSet Set<String> expected) {
 
@@ -295,26 +295,26 @@ public class SetTests {
 
 	@DisplayName(".multiply(Set<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when sets are disjoint, returns product set;" +
 			"[t, E, q]; [e, g];" +
-			"[t/e, t/g, E/e, E/g, q/e, q/g]",
+			"[t:e, t:g, E:e, E:g, q:e, q:g]",
 		"when sets intersect, returns product set;" +
 			"[t, E, q]; [q, E];" +
-			"[t/q, t/E, E/q, E/E, q/q, q/E]",
+			"[t:q, t:E, E:q, E:E, q:q, q:E]",
 		"when sets are equal, returns product set;" +
 			"[t, E, q]; [t, E, q];" +
-			"[t/t, t/E, t/q, E/t, E/E, E/q, q/t, q/E, q/q]",
-		"when set is empty, returns empty set;" +
-			"[]; [P, z, E, q];" +
-			"[]",
+			"[t:t, t:E, t:q, E:t, E:E, E:q, q:t, q:E, q:q]",
 		"when argument set is empty, returns empty set;" +
 			"[t, E, q, v, b, 0]; [];" +
 			"[]",
-		"when both sets are empty, returns empty set;" +
+		"when set is empty, returns empty set;" +
+			"[]; [P, z, E, q];" +
+			"[]",
+		"when both set and argument set are empty, returns empty set;" +
 			"[]; [];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testMultiply(String name, @StringSet Set<String> items1,
 		@StringSet Set<String> items2,
 		@StringPairSet Set<Pair<String, String>> expected) {
@@ -325,17 +325,17 @@ public class SetTests {
 
 	@DisplayName(".filter(Predicate<T>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
-		"when some items match filter, returns filtered items;" +
+	@CsvSource(value = {
+		"when some items match, returns matched items;" +
 			"[r, O, e, Q, s, A, B, P];" +
 			"[r, e, s]",
-		"when no items match filter, returns empty set;" +
+		"when no items match, returns empty set;" +
 			"[R, W, D, L, P];" +
 			"[]",
 		"when set is empty, returns empty items;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testFilter(String name, @StringSet Set<String> items,
 		@StringSet Set<String> expected) {
 
@@ -349,11 +349,11 @@ public class SetTests {
 
 	@DisplayName(".convert(Function<T, R>)")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when set is not empty, returns converted items;" +
 			"[f, R, E, a, A, b, F, L];" +
 			"[f, r, e, a, b, l]",
-		"when some items convert to null, ignores them;" +
+		"when some items convert to null, returns converted non-null items;" +
 			"[f, R, a, B, 2, e, T, 4, 0];" +
 			"[f, r, a, b, e, t]",
 		"when all items convert to null, returns empty set;" +
@@ -362,7 +362,7 @@ public class SetTests {
 		"when set is empty, returns empty set;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testConvert(String name, @StringSet Set<String> items,
 		@StringSet Set<String> expected) {
 
@@ -377,14 +377,14 @@ public class SetTests {
 
 	@DisplayName(".bridge()")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when set is not empty, returns items in java.util.Set;" +
 			"[t, E, a, Q, p, L];" +
 			"[t, E, a, Q, p, L]",
 		"when set is empty, returns empty java.util.Set;" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testBridge(String name, @StringSet Set<String> items,
 		@StringArray String[] expected) {
 
@@ -395,14 +395,14 @@ public class SetTests {
 
 	@DisplayName(".toString()")
 	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
+	@CsvSource(value = {
 		"when set is not empty, converts to string;" +
 			"[N, g, m, R, e, q];" +
 			"[N, g, m, R, e, q]",
 		"when set is empty, converts to [];" +
 			"[];" +
 			"[]"
-	})
+	}, delimiter = ';')
 	void testToString(String name, @StringSet Set<String> items, String expected) {
 		final var string = items.toString();
 		assertEquals(expected, string);
@@ -442,7 +442,7 @@ public class SetTests {
 			return new StringSet.Converter()
 				.convert(s)
 				.convert((item) -> {
-					final var items = item.split("/");
+					final var items = item.split(":");
 					return new Pair<>(items[0], items[1]);
 				});
 		}

--- a/src/test/java/co/tsyba/core/collections/SetTests.java
+++ b/src/test/java/co/tsyba/core/collections/SetTests.java
@@ -1,750 +1,488 @@
 package co.tsyba.core.collections;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.converter.TypedArgumentConverter;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 import java.util.Comparator;
-import java.util.LinkedList;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SetTests {
-	@Nested
 	@DisplayName("Set(Collection<T>)")
-	class NewWithCollectionTests {
-		@Test
-		@DisplayName("creates set")
-		void createsSet() {
-			final var items = new Set<>(
-				new List<>("v", "4", "G", "v", "5"));
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when items are not empty, creates set;" +
+			"[g, R, 2, q, P, s];" +
+			"[g, R, 2, q, P, s]",
+		"when items are empty, creates empty set;" +
+			"[];" +
+			"[]"
+	})
+	void testNewCollection(String name, @StringArray String[] items,
+		@StringSet Set<String> expected) {
 
-			final var store = items.toArray();
-			Arrays.sort(store);
+		final var set = new Set<>(
+			new List<>(items));
 
-			assert Arrays.equals(store,
-				new String[]{
-					"4", "5", "G", "v"
-				});
-		}
-
-		@Test
-		@DisplayName("creates empty set")
-		void createsEmptySet() {
-			final var items = new Set<>(
-				new List<String>());
-
-			final var store = items.toArray();
-			assert 0 == store.length;
-		}
+		assertEquals(expected, set);
 	}
 
-	@Nested
 	@DisplayName("Set(T...)")
-	class NewWithVarargsTests {
-		@Test
-		@DisplayName("creates set")
-		void createsSet() {
-			final var items = new Set<>(2, 7, 5, 4, 9);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when no items are null, creates set;" +
+			"[g, R, l, q, P, s, n];" +
+			"[g, R, l, q, P, s, n]",
+		"when some items are null, creates set with non-null items;" +
+			"[g, null, l, null, P, null, null];" +
+			"[g, l, P]",
+		"when all items are null, creates empty set;" +
+			"[null, null, null, null];" +
+			"[]",
+		"when items are empty, creates empty set;" +
+			"[];" +
+			"[]"
+	})
+	void testNewVarargs(String name, @StringArray String[] items,
+		@StringSet Set<String> expected) {
 
-			final var store = items.toArray();
-			Arrays.sort(store);
-
-			assert Arrays.equals(store,
-				new Integer[]{
-					2, 4, 5, 7, 9
-				});
-		}
-
-		@Test
-		@DisplayName("ignores null values")
-		void ignoresNulls() {
-			final var items = new Set<>("h", "5", null, "R", null, null);
-
-			final var store = items.toArray();
-			Arrays.sort(store);
-
-			assert Arrays.equals(store,
-				new Object[]{
-					"5", "R", "h"
-				});
-		}
-
-		@Test
-		@DisplayName("creates empty set")
-		void createsEmptySet() {
-			final var items = new Set<Integer>();
-
-			final var store = items.toArray();
-			assert 0 == store.length;
-		}
+		final var set = new Set<>(items);
+		assertEquals(expected, set);
 	}
 
-	@Nested
 	@DisplayName("Set(Iterable<T>)")
-	class NewWithIterableTests {
-		@Test
-		@DisplayName("creates set")
-		void createsSet() {
-			final var items = new Set<>(
-				Arrays.asList("b", "Y", "u", "3"));
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when no items are null, creates set;" +
+			"[t, y, O, f, A, s];" +
+			"[t, y, O, f, A, s]",
+		"when some items are null, creates set with non-null items;" +
+			"[l, null, null, P, null, d, null];" +
+			"[l, P, d]",
+		"when all items are null, creates empty set;" +
+			"[null, null];" +
+			"[]",
+		"when items are empty, creates empty set;" +
+			"[];" +
+			"[]"
+	})
+	void testNewIterable(String name, @StringArray String[] items,
+		@StringSet Set<String> expected) {
 
-			final var store = items.toArray();
-			Arrays.sort(store);
+		final var set = new Set<>(
+			Arrays.asList(items));
 
-			assert Arrays.equals(store,
-				new String[]{
-					"3", "Y", "b", "u"
-				});
-		}
-
-		@Test
-		@DisplayName("ignores null values")
-		void ignoresNulls() {
-			final var items = new Set<>(
-				Arrays.asList(null, "y", "5", null, "4", "5"));
-
-			final var store = items.toArray();
-			Arrays.sort(store);
-
-			assert Arrays.equals(store,
-				new Object[]{
-					"4", "5", "y"
-				});
-		}
-
-		@Test
-		@DisplayName("creates empty set")
-		void createsEmptySet() {
-			final var items = new Set<Integer>(
-				new LinkedList<>());
-
-			final var store = items.toArray();
-			assert 0 == store.length;
-		}
+		assertEquals(expected, set);
 	}
 
-	@Nested
 	@DisplayName(".getCount()")
-	class GetCountTests {
-		@Test
-		@DisplayName("when set is not empty, returns item count")
-		void returnsItemCountWhenNotEmpty() {
-			final var items = new Set<>(5, 3, 2, 1, 0, 9, 7);
-			final var count = items.getCount();
-			assert 7 == count;
-		}
-
-		@Test
-		@DisplayName("when set is empty, returns 0")
-		void returnsZeroWhenEmpty() {
-			final var items = new Set<>();
-			final var count = items.getCount();
-			assert 0 == count;
-		}
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when set is not empty, returns item count;" +
+			"[g, b, L, f, s, O, k];" +
+			"7",
+		"when set is empty, returns 0;" +
+			"[];" +
+			"0"
+	})
+	void testGetCount(String name, @StringSet Set<String> items, int expected) {
+		final var count = items.getCount();
+		assertEquals(expected, count);
 	}
 
-	@Nested
 	@DisplayName(".contains(T)")
-	class ContainsTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			private final Set<Integer> items = new Set<>(6, 4, 2, 0, 9, 7);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when item is present, returns true;" +
+			"[b, K, s, L, m, s, D]; m;" +
+			"true",
+		"when item is absent, returns false;" +
+			"[b, K, s, L, m, s, D]; M;" +
+			"false",
+		"when item is null, returns false;" +
+			"[b, K, s, L, m, s, D]; ;" +
+			"false",
+		"when set is empty, returns false;" +
+			"[]; m;" +
+			"false",
+	})
+	void testContains(String name, @StringSet Set<String> items, String item,
+		boolean expected) {
 
-			@Test
-			@DisplayName("when item is present, returns true")
-			void returnsTrueWhenItemPresent() {
-				assert items.contains(0);
-			}
-
-			@Test
-			@DisplayName("when item is absent, returns false")
-			void returnsFalseWhenItemAbsent() {
-				assert !items.contains(5);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptySetTests {
-			private final Set<Integer> items = new Set<>();
-
-			@Test
-			@DisplayName("returns false")
-			void returnsFalseWhenEmpty() {
-				assert !items.contains(0);
-			}
-		}
+		final var contains = items.contains(item);
+		assertEquals(expected, contains);
 	}
 
-	@Nested
 	@DisplayName(".isDisjoint(Set<T>)")
-	class IsDisjointTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			private final Set<String> set1 = new Set<>("t", "E", "q", "v", "b", "0");
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when sets are disjoint, returns true;" +
+			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
+			"true",
+		"when sets intersect, returns false;" +
+			"[t, E, q, v, b, 0]; [P, z, E, q];" +
+			"false",
+		"when sets are equal, returns false;" +
+			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
+			"false",
+		"when set is empty, returns true;" +
+			"[]; [P, z, E, q];" +
+			"true",
+		"when argument set is empty, returns true;" +
+			"[t, E, q, v, b, 0]; [];" +
+			"true",
+		"when both sets are empty, returns true;" +
+			"[]; [];" +
+			"true"
+	})
+	void testIsDisjoint(String name, @StringSet Set<String> items1,
+		@StringSet Set<String> items2, boolean expected) {
 
-			@Test
-			@DisplayName("when sets are disjoint, returns true")
-			void returnsTrueWhenDisjoint() {
-				final var set2 = new Set<>("e", "g", "7", "T");
-				assert set1.isDisjoint(set2);
-			}
-
-			@Test
-			@DisplayName("when sets intersect, returns false")
-			void returnsFalseWhenIntersects() {
-				final var set2 = new Set<>("P", "z", "E", "q");
-				assert !set1.isDisjoint(set2);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns true")
-			void returnsFalseWhenOtherSetEmpty() {
-				final var set2 = new Set<String>();
-				assert set1.isDisjoint(set2);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptySetTests {
-			private final Set<String> set1 = new Set<>();
-
-			@Test
-			@DisplayName("when other set is not empty, returns true")
-			void returnsFalseWhenOtherSetIsNotEmpty() {
-				final var set2 = new Set<>("P", "z", "e", "Q");
-				assert set1.isDisjoint(set2);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns true")
-			void returnsFalseWhenOtherSetIsEmpty() {
-				final var set2 = new Set<String>();
-				assert set1.isDisjoint(set2);
-			}
-		}
+		final var disjoint = items1.isDisjoint(items2);
+		assertEquals(expected, disjoint);
 	}
 
-	@Nested
 	@DisplayName(".unite(Set<T>)")
-	class UniteTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			private final Set<Integer> set1 = new Set<>(5, 4, 7, 8, 0);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when sets are disjoint, returns union set;" +
+			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
+			"[t, E, q, v, b, 0, e, g, 7, T]",
+		"when sets intersect, returns union set;" +
+			"[t, E, q, v, b, 0]; [P, z, E, q];" +
+			"[t, E, q, v, b, 0, P, z]",
+		"when sets are equal, returns union set;" +
+			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
+			"[t, E, q, v, b, 0]",
+		"when set is empty, returns union set;" +
+			"[]; [P, z, E, q];" +
+			"[P, z, E, q]",
+		"when argument set is empty, returns union set;" +
+			"[t, E, q, v, b, 0]; [];" +
+			"[t, E, q, v, b, 0]",
+		"when both sets are empty, returns empty set;" +
+			"[]; [];" +
+			"[]"
+	})
+	void testUnite(String name, @StringSet Set<String> items1,
+		@StringSet Set<String> items2, @StringSet Set<String> expected) {
 
-			@Test
-			@DisplayName("when other set is not empty, returns union")
-			void returnsUnionWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>(5, 0, 2, 3);
-				final var union = set1.unite(set2);
-
-				assert new Set<>(0, 2, 3, 5, 4, 7, 8)
-					.equals(union);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns set")
-			void returnsSetWhenOtherSetEmpty() {
-				final var set2 = new Set<Integer>();
-				final var union = set1.unite(set2);
-
-				assert new Set<>(5, 4, 7, 8, 0)
-					.equals(union);
-			}
-
-			@Test
-			@DisplayName("when sets are equal, returns union")
-			void returnsUnionWhenSetsEqual() {
-				final var set2 = new Set<>(set1);
-				final var intersection = set1.intersect(set2);
-
-				assert new Set<>(5, 4, 7, 8, 0)
-					.equals(intersection);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptySetTests {
-			private final Set<Integer> set1 = new Set<>();
-
-			@Test
-			@DisplayName("when other set is not empty, returns other set")
-			void returnsOtherSetWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>(5, 0, 2, 3);
-				final var union = set1.unite(set2);
-
-				assert new Set<>(5, 0, 2, 3)
-					.equals(union);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns empty set")
-			void returnsEmptySetWhenOtherSetEmpty() {
-				final var set2 = new Set<Integer>();
-				final var union = set1.unite(set2);
-
-				assert new Set<>()
-					.equals(union);
-			}
-		}
+		final var union = items1.unite(items2);
+		assertEquals(expected, union);
 	}
 
-	@Nested
 	@DisplayName(".intersects(Set<T>)")
-	class IntersectsTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			private final Set<String> set1 = new Set<>("t", "E", "q", "v", "b", "0");
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when sets are disjoint, returns false;" +
+			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
+			"false",
+		"when sets intersect, returns true;" +
+			"[t, E, q, v, b, 0]; [P, z, E, q];" +
+			"true",
+		"when sets are equal, returns true;" +
+			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
+			"true",
+		"when set is empty, returns false;" +
+			"[]; [P, z, E, q];" +
+			"false",
+		"when argument set is empty, returns false;" +
+			"[t, E, q, v, b, 0]; [];" +
+			"false",
+		"when both sets are empty, returns false;" +
+			"[]; [];" +
+			"false"
+	})
+	void testIntersects(String name, @StringSet Set<String> items1,
+		@StringSet Set<String> items2, boolean expected) {
 
-			@Test
-			@DisplayName("when sets intersect, returns true")
-			void returnsTrueWhenIntersects() {
-				final var set2 = new Set<>("E", "g", "7", "t");
-				assert set1.intersects(set2);
-			}
-
-			@Test
-			@DisplayName("when sets do not intersect, returns false")
-			void returnsFalseWhenDisjoint() {
-				final var set2 = new Set<>("P", "z", "e", "Q");
-				assert !set1.intersects(set2);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns false")
-			void returnsFalseWhenOtherSetEmpty() {
-				final var set2 = new Set<String>();
-				assert !set1.intersects(set2);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptySetTests {
-			private final Set<String> set1 = new Set<>();
-
-			@Test
-			@DisplayName("when other set is not empty, returns false")
-			void returnsFalseWhenOtherSetIsNotEmpty() {
-				final var set2 = new Set<>("P", "z", "e", "Q");
-				assert !set1.intersects(set2);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns false")
-			void returnsFalseWhenOtherSetIsEmpty() {
-				final var set2 = new Set<String>();
-				assert !set1.intersects(set2);
-			}
-		}
+		final var intersects = items1.intersects(items2);
+		assertEquals(expected, intersects);
 	}
 
-	@Nested
 	@DisplayName(".intersect(Set<T>)")
-	class IntersectTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			private final Set<Integer> set1 = new Set<>(5, 4, 7, 8, 0);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when sets are disjoint, returns empty set;" +
+			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
+			"[]",
+		"when sets intersect, returns intersection set;" +
+			"[t, E, q, v, b, 0]; [P, z, E, q];" +
+			"[E, q]",
+		"when sets are equal, returns intersection set;" +
+			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
+			"[t, E, q, v, b, 0]",
+		"when set is empty, returns empty set;" +
+			"[]; [P, z, E, q];" +
+			"[]",
+		"when argument set is empty, returns empty set;" +
+			"[t, E, q, v, b, 0]; [];" +
+			"[]",
+		"when both sets are empty, returns empty set;" +
+			"[]; [];" +
+			"[]"
+	})
+	void testIntersect(String name, @StringSet Set<String> items1,
+		@StringSet Set<String> items2, @StringSet Set<String> expected) {
 
-			@Test
-			@DisplayName("when other set is not empty, returns intersection")
-			void returnsIntersectionWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>(5, 0, 2, 3);
-				final var intersection = set1.intersect(set2);
-
-				assert new Set<>(0, 5)
-					.equals(intersection);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns empty set")
-			void returnsEmptySetWhenOtherSetEmpty() {
-				final var set2 = new Set<Integer>();
-				final var intersection = set1.intersect(set2);
-
-				assert new Set<>()
-					.equals(intersection);
-			}
-
-			@Test
-			@DisplayName("when sets are equal, returns intersection")
-			void returnsIntersectionWhenSetsEqual() {
-				final var set2 = new Set<>(set1);
-				final var intersection = set1.intersect(set2);
-
-				assert new Set<>(5, 4, 7, 8, 0)
-					.equals(intersection);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptySetTests {
-			private final Set<Integer> set1 = new Set<>();
-
-			@Test
-			@DisplayName("when other set is not empty, returns empty set")
-			void returnsEmptySetWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>(5, 0, 2, 3);
-				final var intersection = set1.intersect(set2);
-
-				assert new Set<>()
-					.equals(intersection);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns empty set")
-			void returnsEmptySetWhenOtherSetEmpty() {
-				final var set2 = new Set<Integer>();
-				final var intersection = set1.intersect(set2);
-
-				assert new Set<>()
-					.equals(intersection);
-			}
-		}
+		final var intersection = items1.intersect(items2);
+		assertEquals(expected, intersection);
 	}
 
-	@Nested
 	@DisplayName(".subtract(Set<T>)")
-	class SubtractTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			private final Set<Integer> set1 = new Set<>(5, 4, 7, 8, 0);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when sets are disjoint, returns difference set;" +
+			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
+			"[t, E, q, v, b, 0]",
+		"when sets intersect, returns difference set;" +
+			"[t, E, q, v, b, 0]; [P, z, E, q];" +
+			"[t, v, b, 0]",
+		"when sets are equal, returns empty set;" +
+			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
+			"[]",
+		"when set is empty, returns empty set;" +
+			"[]; [P, z, E, q];" +
+			"[]",
+		"when argument set is empty, returns difference set;" +
+			"[t, E, q, v, b, 0]; [];" +
+			"[t, E, q, v, b, 0]",
+		"when both sets are empty, returns empty set;" +
+			"[]; [];" +
+			"[]"
+	})
+	void testSubtract(String name, @StringSet Set<String> items1,
+		@StringSet Set<String> items2, @StringSet Set<String> expected) {
 
-			@Test
-			@DisplayName("when other set is not empty, returns difference")
-			void returnsDifferenceWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>(5, 0, 2, 3);
-				final var difference = set1.subtract(set2);
-
-				assert new Set<>(4, 7, 8)
-					.equals(difference);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns set")
-			void returnsSetWhenOtherSetEmpty() {
-				final var set2 = new Set<Integer>();
-				final var difference = set1.subtract(set2);
-
-				assert new Set<>(5, 4, 7, 8, 0)
-					.equals(difference);
-			}
-
-			@Test
-			@DisplayName("when sets are equal, returns empty set")
-			void returnsEmptySetWhenSetsEqual() {
-				final var set2 = new Set<>(set1);
-				final var difference = set1.subtract(set2);
-
-				assert new Set<>()
-					.equals(difference);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptySetTests {
-			private final Set<Integer> set1 = new Set<>();
-
-			@Test
-			@DisplayName("when other set is not empty, returns empty set")
-			void returnsEmptySetWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>(5, 0, 2, 3);
-				final var difference = set1.subtract(set2);
-
-				assert new Set<>()
-					.equals(difference);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns empty set")
-			void returnsEmptySetWhenOtherSetEmpty() {
-				final var set2 = new Set<Integer>();
-				final var difference = set1.subtract(set2);
-
-				assert new Set<>()
-					.equals(difference);
-			}
-		}
+		final var difference = items1.subtract(items2);
+		assertEquals(expected, difference);
 	}
 
-	@Nested
 	@DisplayName(".symmetricSubtract(Set<T>)")
-	class SymmetricSubtractTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			private final Set<Integer> set1 = new Set<>(5, 4, 7, 8, 0);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when sets are disjoint, returns symmetric difference set;" +
+			"[t, E, q, v, b, 0]; [e, g, 7, T];" +
+			"[t, E, q, v, b, 0, e, g, 7, T]",
+		"when sets intersect, returns symmetric difference set;" +
+			"[t, E, q, v, b, 0]; [P, z, E, q];" +
+			"[t, v, b, 0, P, z]",
+		"when sets are equal, returns empty set;" +
+			"[t, E, q, v, b, 0]; [t, E, q, v, b, 0];" +
+			"[]",
+		"when set is empty, returns symmetric difference set;" +
+			"[]; [P, z, E, q];" +
+			"[P, z, E, q]",
+		"when argument set is empty, returns symmetric difference set;" +
+			"[t, E, q, v, b, 0]; [];" +
+			"[t, E, q, v, b, 0]",
+		"when both sets are empty, returns empty set;" +
+			"[]; [];" +
+			"[]"
+	})
+	void testSymmetricSubtract(String name, @StringSet Set<String> items1,
+		@StringSet Set<String> items2, @StringSet Set<String> expected) {
 
-			@Test
-			@DisplayName("when other set is not empty, returns symmetric difference")
-			void returnsDifferenceWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>(5, 0, 2, 3);
-				final var difference = set1.symmetricSubtract(set2);
-
-				assert new Set<>(4, 7, 8, 2, 3)
-					.equals(difference);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns set")
-			void returnsSetWhenOtherSetEmpty() {
-				final var set2 = new Set<Integer>();
-				final var difference = set1.symmetricSubtract(set2);
-
-				assert new Set<>(5, 4, 7, 8, 0)
-					.equals(difference);
-			}
-
-			@Test
-			@DisplayName("when sets are equal, returns empty set")
-			void returnsEmptySetWhenSetsEqual() {
-				final var set2 = new Set<>(set1);
-				final var difference = set1.symmetricSubtract(set2);
-
-				assert new Set<>()
-					.equals(difference);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptySetTests {
-			private final Set<Integer> set1 = new Set<>();
-
-			@Test
-			@DisplayName("when other set is not empty, returns other set")
-			void returnsOtherSetWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>(5, 0, 2, 3);
-				final var difference = set1.symmetricSubtract(set2);
-
-				assert new Set<>(5, 0, 2, 3)
-					.equals(difference);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns empty set")
-			void returnsEmptySetWhenOtherSetEmpty() {
-				final var set2 = new Set<Integer>();
-				final var difference = set1.symmetricSubtract(set2);
-
-				assert new Set<>()
-					.equals(difference);
-			}
-		}
+		final var difference = items1.symmetricSubtract(items2);
+		assertEquals(expected, difference);
 	}
 
-	@Nested
 	@DisplayName(".multiply(Set<T>)")
-	class MultiplyTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			private final Set<Integer> set1 = new Set<>(5, 8, 0);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when sets are disjoint, returns product set;" +
+			"[t, E, q]; [e, g];" +
+			"[t/e, t/g, E/e, E/g, q/e, q/g]",
+		"when sets intersect, returns product set;" +
+			"[t, E, q]; [q, E];" +
+			"[t/q, t/E, E/q, E/E, q/q, q/E]",
+		"when sets are equal, returns product set;" +
+			"[t, E, q]; [t, E, q];" +
+			"[t/t, t/E, t/q, E/t, E/E, E/q, q/t, q/E, q/q]",
+		"when set is empty, returns empty set;" +
+			"[]; [P, z, E, q];" +
+			"[]",
+		"when argument set is empty, returns empty set;" +
+			"[t, E, q, v, b, 0]; [];" +
+			"[]",
+		"when both sets are empty, returns empty set;" +
+			"[]; [];" +
+			"[]"
+	})
+	void testMultiply(String name, @StringSet Set<String> items1,
+		@StringSet Set<String> items2,
+		@StringPairSet Set<Pair<String, String>> expected) {
 
-			@Test
-			@DisplayName("when other set is not empty, returns cartesian product")
-			void returnsProductWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>("0", "2");
-				final var product = set1.multiply(set2);
-
-				final var expected = new Set<>(
-					new Pair<>(5, "0"), new Pair<>(5, "2"),
-					new Pair<>(8, "0"), new Pair<>(8, "2"),
-					new Pair<>(0, "0"), new Pair<>(0, "2"));
-
-				assert expected.equals(product);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns empty set")
-			void returnsEmptySetWhenOtherSetEmpty() {
-				final var set2 = new Set<String>();
-				final var product = set1.multiply(set2);
-
-				assert new Set<Pair<Integer, String>>()
-					.equals(product);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptySetTests {
-			private final Set<Integer> set1 = new Set<>();
-
-			@Test
-			@DisplayName("when other set is not empty, returns empty set")
-			void returnsEmptySetWhenOtherSetNotEmpty() {
-				final var set2 = new Set<>("0", "2");
-				final var product = set1.multiply(set2);
-
-				assert new Set<Pair<Integer, String>>()
-					.equals(product);
-			}
-
-			@Test
-			@DisplayName("when other set is empty, returns empty set")
-			void returnsEmptySetWhenOtherSetEmpty() {
-				final var set2 = new Set<String>();
-				final var product = set1.multiply(set2);
-
-				assert new Set<Pair<Integer, String>>()
-					.equals(product);
-			}
-		}
+		final var product = items1.multiply(items2);
+		assertEquals(expected, product);
 	}
 
-	@Nested
 	@DisplayName(".sort(Comparator<T>)")
-	class SortTests {
-		@Test
-		@DisplayName("when set is not empty, returns sorted items")
-		void returnsSortedItemsWhenNotEmpty() {
-			final var items = new Set<>("g", "G", "k", "q", "0", "P");
-			final var sorted = items.sort(Comparator.naturalOrder());
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when set is not empty, returns sorted list;" +
+			"[k, M, s, A, 8, d, q];" +
+			"[8, A, M, d, k, q, s]",
+		"when set is empty, returns empty list;" +
+			"[];" +
+			"[]"
+	})
+	void testSort(String name, @StringSet Set<String> items,
+		@StringList List<String> expected) {
 
-			assert new List<>("0", "G", "P", "g", "k", "q")
-				.equals(sorted);
-		}
-
-		@Test
-		@DisplayName("when set is empty, returns empty set")
-		void returnsEmptySetWhenEmpty() {
-			final var items = new Set<String>();
-			final var sorted = items.sort(Comparator.naturalOrder());
-
-			assert new List<String>()
-				.equals(sorted);
-		}
+		final var sorted = items.sort(Comparator.naturalOrder());
+		Assertions.assertEquals(expected, sorted);
 	}
 
-	@Nested
 	@DisplayName(".filter(Predicate<T>)")
-	class FilterTests {
-		@Test
-		@DisplayName("when set is not empty, returns filtered items")
-		void returnsFilteredItemsWhenNotEmpty() {
-			final var items = new Set<>(2, 4, 3, 2, 1, 9);
-			final var odds = items.filter((item) ->
-				item % 2 == 1);
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when some items match filter, returns filtered items;" +
+			"[r, O, e, Q, s, A, B, P];" +
+			"[r, e, s]",
+		"when no items match filter, returns empty set;" +
+			"[R, W, D, L, P];" +
+			"[]",
+		"when set is empty, returns empty items;" +
+			"[];" +
+			"[]"
+	})
+	void testFilter(String name, @StringSet Set<String> items,
+		@StringSet Set<String> expected) {
 
-			assert new Set<>(3, 1, 9)
-				.equals(odds);
-		}
+		final var filtered = items.filter((item) -> {
+			return item.toLowerCase()
+				.equals(item);
+		});
 
-		@Test
-		@DisplayName("when list is empty, returns empty list")
-		void returnsEmptySetWhenEmpty() {
-			final var items = new Set<Integer>();
-			final var evens = items.filter((item) ->
-				item % 2 == 0);
-
-			assert new Set<Integer>()
-				.equals(evens);
-		}
+		assertEquals(expected, filtered);
 	}
 
-	@Nested
 	@DisplayName(".convert(Function<T, R>)")
-	class ConvertTests {
-		@Nested
-		@DisplayName("when set is not empty")
-		class NotEmptySetTests {
-			@Test
-			@DisplayName("converts items")
-			void returnsConvertedItems() {
-				final var items = new Set<>(3, 6, 1, 2);
-				final var converted = items.convert((item) ->
-					Integer.toString(item));
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when set is not empty, returns converted items;" +
+			"[f, R, E, a, A, b, F, L];" +
+			"[f, r, e, a, b, l]",
+		"when some items convert to null, ignores them;" +
+			"[f, R, a, B, 2, e, T, 4, 0];" +
+			"[f, r, a, b, e, t]",
+		"when all items convert to null, returns empty set;" +
+			"[4, 5, 1, 0];" +
+			"[]",
+		"when set is empty, returns empty set;" +
+			"[];" +
+			"[]"
+	})
+	void testConvert(String name, @StringSet Set<String> items,
+		@StringSet Set<String> expected) {
 
-				assert new Set<>("3", "6", "1", "2")
-					.equals(converted);
-			}
+		final var converted = items.convert((item) -> {
+			return item.matches("\\d+")
+				? null
+				: item.toLowerCase();
+		});
 
-			@Test
-			@DisplayName("ignores items converted to null")
-			void ignoresItemsConvertedToNull() {
-				final var items = new Set<>(4, 6, 2, 1, 7, 8, 5);
-				final var converted = items.convert((item) ->
-					item % 2 == 0
-						? Integer.toString(item)
-						: null);
-
-				assert new Set<>("4", "6", "2", "8")
-					.equals(converted);
-			}
-		}
-
-		@Nested
-		@DisplayName("when set is empty")
-		class EmptyListTests {
-			@Test
-			@DisplayName("returns empty set")
-			void returnsEmptySetWhenEmpty() {
-				final var items = new Set<Integer>();
-				final var converted = items.convert((item) ->
-					item * 2);
-
-				assert new Set<Integer>()
-					.equals(converted);
-			}
-		}
+		assertEquals(expected, converted);
 	}
 
-	@Nested
-	@DisplayName(".toString()")
-	class BridgeTests {
-		@Test
-		@DisplayName("when set is not empty, returns items in java.util.Set")
-		void returnsSetWhenNotEmpty() {
-			final var items = new Set<>("g", "H", "6", "c", "E");
-			final var set = items.bridge();
+	@DisplayName(".bridge()")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when set is not empty, returns items in java.util.Set;" +
+			"[t, E, a, Q, p, L];" +
+			"[t, E, a, Q, p, L]",
+		"when set is empty, returns empty java.util.Set;" +
+			"[];" +
+			"[]"
+	})
+	void testBridge(String name, @StringSet Set<String> items,
+		@StringArray String[] expected) {
 
-			assert java.util.Set.of("g", "H", "6", "c", "E")
-				.equals(set);
-		}
-
-		@Test
-		@DisplayName("when set is empty, returns empty java.util.Set")
-		void returnsSetWhenEmpty() {
-			final var items = new Set<>();
-			final var set = items.bridge();
-
-			assert java.util.Set.of()
-				.equals(set);
-		}
+		final var expected2 = java.util.Set.of(expected);
+		final var set = items.bridge();
+		assertEquals(expected2, set);
 	}
 
-	@Nested
 	@DisplayName(".toString()")
-	class ToStringTests {
-		@Test
-		@DisplayName("when set is not empty, converts to string")
-		void returnsStringWhenNotEmpty() {
-			final var items = new List<>("g", "H", "6", "c", "E");
-			final var string = items.toString();
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(delimiter = ';', value = {
+		"when set is not empty, converts to string;" +
+			"[N, g, m, R, e, q];" +
+			"[N, g, m, R, e, q]",
+		"when set is empty, converts to [];" +
+			"[];" +
+			"[]"
+	})
+	void testToString(String name, @StringSet Set<String> items, String expected) {
+		final var string = items.toString();
+		assertEquals(expected, string);
+	}
+}
 
-			assert "[g, H, 6, c, E]"
-				.equals(string);
+@Retention(RetentionPolicy.RUNTIME)
+@ConvertWith(StringSet.Converter.class)
+@interface StringSet {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, Set> {
+		protected Converter() {
+			super(String.class, Set.class);
 		}
 
-		@Test
-		@DisplayName("when set is empty, returns []")
-		void returnsStringWhenEmpty() {
-			final var items = new List<>();
-			final var string = items.toString();
+		@Override
+		protected Set<String> convert(String s) throws ArgumentConversionException {
+			final var items = new StringArray.Converter()
+				.convert(s);
 
-			assert "[]"
-				.equals(string);
+			return new Set<>(items);
+		}
+	}
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConvertWith(StringPairSet.Converter.class)
+@interface StringPairSet {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, Set> {
+		protected Converter() {
+			super(String.class, Set.class);
+		}
+
+		@Override
+		protected Set<Pair<String, String>> convert(String s) throws ArgumentConversionException {
+			return new StringSet.Converter()
+				.convert(s)
+				.convert((item) -> {
+					final var items = item.split("/");
+					return new Pair<>(items[0], items[1]);
+				});
+		}
+	}
+}
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConvertWith(StringList.Converter.class)
+@interface StringList {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, List> {
+		protected Converter() {
+			super(String.class, List.class);
+		}
+
+		@Override
+		protected List<String> convert(String s) throws ArgumentConversionException {
+			final var items = new StringArray.Converter()
+				.convert(s);
+
+			return new List<>(items);
 		}
 	}
 }

--- a/src/test/java/co/tsyba/core/collections/SetTests.java
+++ b/src/test/java/co/tsyba/core/collections/SetTests.java
@@ -1,6 +1,5 @@
 package co.tsyba.core.collections;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
@@ -11,7 +10,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
-import java.util.Comparator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -323,23 +321,6 @@ public class SetTests {
 
 		final var product = items1.multiply(items2);
 		assertEquals(expected, product);
-	}
-
-	@DisplayName(".sort(Comparator<T>)")
-	@ParameterizedTest(name = "{0}")
-	@CsvSource(delimiter = ';', value = {
-		"when set is not empty, returns sorted list;" +
-			"[k, M, s, A, 8, d, q];" +
-			"[8, A, M, d, k, q, s]",
-		"when set is empty, returns empty list;" +
-			"[];" +
-			"[]"
-	})
-	void testSort(String name, @StringSet Set<String> items,
-		@StringList List<String> expected) {
-
-		final var sorted = items.sort(Comparator.naturalOrder());
-		Assertions.assertEquals(expected, sorted);
 	}
 
 	@DisplayName(".filter(Predicate<T>)")


### PR DESCRIPTION
This update converts units tests for `Collection`, `Set` and `MutableSet` to parametrised sets. Additionally, it updates `Set` and `MutableSet` to return instances of themselves in methods, which return a `Collection`.