### PR TITLE
Small improvements to Collections interface.

### DIFF
--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -65,6 +65,19 @@ public interface Collection<T> extends Iterable<T> {
 	}
 
 	/**
+	 * Returns the smallest item in this collection, according to the natural order of the
+	 * items.
+	 *
+	 * @throws UnsupportedOperationException when items of this collection are not
+	 * {@link Comparable}
+	 */
+	default Optional<T> getMin() {
+		@SuppressWarnings("unchecked")
+		final var comparator = (Comparator<T>) Comparator.naturalOrder();
+		return getMin(comparator);
+	}
+
+	/**
 	 * Returns the largest item in this collection, according to the specified
 	 * {@link Comparator}.
 	 * <p>
@@ -85,6 +98,19 @@ public interface Collection<T> extends Iterable<T> {
 		}
 
 		return Optional.of(maximum);
+	}
+
+	/**
+	 * Returns the largest item in this collection, according to the natural order of the
+	 * items.
+	 *
+	 * @throws UnsupportedOperationException when items of this collection are not
+	 * {@link Comparable}
+	 */
+	default Optional<T> getMax() {
+		@SuppressWarnings("unchecked")
+		final var comparator = (Comparator<T>) Comparator.naturalOrder();
+		return getMax(comparator);
 	}
 
 	/**
@@ -168,8 +194,7 @@ public interface Collection<T> extends Iterable<T> {
 	}
 
 	/**
-	 * Returns items of this collection, ordered according to their natural order, when
-	 * items are {@link Comparable}; otherwise fails with {@link RuntimeException}.
+	 * Returns items of this collection, ordered according to their natural order.
 	 *
 	 * @throws RuntimeException when items of this collection are not {@link Comparable}.
 	 */

--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -47,7 +47,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * <p>
 	 * When this collection is empty, returns an empty {@link Optional}.
 	 */
-	default Optional<T> getMinimum(Comparator<T> comparator) {
+	default Optional<T> getMin(Comparator<T> comparator) {
 		final var iterator = iterator();
 		if (!iterator.hasNext()) {
 			return Optional.empty();
@@ -70,7 +70,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * <p>
 	 * When this collection is empty, returns an empty {@link Optional}.
 	 */
-	default Optional<T> getMaximum(Comparator<T> comparator) {
+	default Optional<T> getMax(Comparator<T> comparator) {
 		final var iterator = iterator();
 		if (!iterator.hasNext()) {
 			return Optional.empty();

--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -189,7 +189,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * Returns items of this collection, ordered according to the specified
 	 * {@link Comparator}.
 	 */
-	default List<T> sort(Comparator<T> comparator) {
+	default Sequence<T> sort(Comparator<T> comparator) {
 		@SuppressWarnings("unchecked")
 		final var items = (T[]) toArray();
 		Arrays.sort(items, comparator);
@@ -203,7 +203,7 @@ public interface Collection<T> extends Iterable<T> {
 	 *
 	 * @throws RuntimeException when items of this collection are not {@link Comparable}.
 	 */
-	default List<T> sort() {
+	default Sequence<T> sort() {
 		@SuppressWarnings("unchecked")
 		final var comparator = (Comparator<T>) Comparator.naturalOrder();
 		return sort(comparator);
@@ -213,7 +213,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * Returns items of this collection in random order, based on the specified
 	 * {@link Random}.
 	 */
-	default List<T> shuffle(Random random) {
+	default Sequence<T> shuffle(Random random) {
 		final var items = toArray();
 		shuffle(items, random);
 
@@ -225,7 +225,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * Returns items of this collection in random order, where randomization is seeded
 	 * from the current system time.
 	 */
-	default List<T> shuffle() {
+	default Sequence<T> shuffle() {
 		final var time = System.currentTimeMillis();
 		final var random = new Random(time);
 

--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -181,6 +181,11 @@ public interface Collection<T> extends Iterable<T> {
 	}
 
 	/**
+	 * Returns distinct items in this collection.
+	 */
+	Collection<T> getDistinct();
+
+	/**
 	 * Returns items of this collection, ordered according to the specified
 	 * {@link Comparator}.
 	 */

--- a/src/main/java/co/tsyba/core/collections/Collection.java
+++ b/src/main/java/co/tsyba/core/collections/Collection.java
@@ -118,7 +118,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * {@code false} otherwise.
 	 */
 	default boolean contains(T item) {
-		return match((item2) -> item2.equals(item))
+		return matchAny((item2) -> item2.equals(item))
 			.isPresent();
 	}
 
@@ -131,30 +131,13 @@ public interface Collection<T> extends Iterable<T> {
 	}
 
 	/**
-	 * Returns any item in this collection, which satisfies the specified
-	 * {@link Predicate}.
-	 * <p>
-	 * When no item in this collection satisfies the specified {@link Predicate}, or this
-	 * collection is empty, returns an empty {@link Optional}.
-	 */
-	default Optional<T> match(Predicate<T> condition) {
-		for (var item : this) {
-			if (condition.test(item)) {
-				return Optional.of(item);
-			}
-		}
-
-		return Optional.empty();
-	}
-
-	/**
 	 * Returns {@code true} when no item in this collection satisfies the specified
 	 * {@link Predicate}; returns {@code false} otherwise.
 	 * <p>
 	 * When this collection is empty, returns {@code true}.
 	 */
 	default boolean noneMatches(Predicate<T> condition) {
-		return match(condition)
+		return matchAny(condition)
 			.isEmpty();
 	}
 
@@ -165,7 +148,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * When this collection is empty, returns {@code false}.
 	 */
 	default boolean anyMatches(Predicate<T> condition) {
-		return match(condition)
+		return matchAny(condition)
 			.isPresent();
 	}
 
@@ -176,8 +159,25 @@ public interface Collection<T> extends Iterable<T> {
 	 * When this collection is empty, returns {@code true}.
 	 */
 	default boolean eachMatches(Predicate<T> condition) {
-		return match((item) -> !condition.test(item))
+		return matchAny((item) -> !condition.test(item))
 			.isEmpty();
+	}
+
+	/**
+	 * Returns any item in this collection, which satisfies the specified
+	 * {@link Predicate}.
+	 * <p>
+	 * When no item in this collection satisfies the specified {@link Predicate}, or this
+	 * collection is empty, returns an empty {@link Optional}.
+	 */
+	default Optional<T> matchAny(Predicate<T> condition) {
+		for (var item : this) {
+			if (condition.test(item)) {
+				return Optional.of(item);
+			}
+		}
+
+		return Optional.empty();
 	}
 
 	/**

--- a/src/main/java/co/tsyba/core/collections/IndexRange.java
+++ b/src/main/java/co/tsyba/core/collections/IndexRange.java
@@ -176,6 +176,11 @@ public class IndexRange implements Sequence<Integer> {
 	}
 
 	@Override
+	public IndexRange getDistinct() {
+		return this;
+	}
+
+	@Override
 	public Sequence<Integer> reverse() {
 		// todo: implement IndexRange.reverse()
 		throw new UnsupportedOperationException();

--- a/src/main/java/co/tsyba/core/collections/List.java
+++ b/src/main/java/co/tsyba/core/collections/List.java
@@ -142,9 +142,7 @@ public class List<T> implements Sequence<T> {
 		return !iterator2.hasNext();
 	}
 
-	/**
-	 * Returns distinct items in this list.
-	 */
+	@Override
 	public List<T> getDistinct() {
 		final var distinct = new MutableSet<>(this);
 		return new List<>(distinct);

--- a/src/main/java/co/tsyba/core/collections/MutableList.java
+++ b/src/main/java/co/tsyba/core/collections/MutableList.java
@@ -2,7 +2,6 @@ package co.tsyba.core.collections;
 
 import java.util.Comparator;
 import java.util.Random;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -346,25 +345,25 @@ public class MutableList<T> extends List<T> {
 
 	@Override
 	public MutableList<T> sort(Comparator<T> comparator) {
-		final var sorted = super.sort(comparator);
+		final var sorted = (List<T>) super.sort(comparator);
 		return new MutableList<>(sorted.store);
 	}
 
 	@Override
 	public List<T> sort() {
-		final var sorted = super.sort();
+		final var sorted = (List<T>) super.sort();
 		return new MutableList<>(sorted.store);
 	}
 
 	@Override
 	public MutableList<T> shuffle(Random random) {
-		final var shuffled = super.shuffle(random);
+		final var shuffled = (List<T>) super.shuffle(random);
 		return new MutableList<>(shuffled.store);
 	}
 
 	@Override
 	public List<T> shuffle() {
-		final var shuffled = super.shuffle();
+		final var shuffled = (List<T>) super.shuffle();
 		return new MutableList<>(shuffled.store);
 	}
 

--- a/src/main/java/co/tsyba/core/collections/MutableSet.java
+++ b/src/main/java/co/tsyba/core/collections/MutableSet.java
@@ -22,6 +22,11 @@ public class MutableSet<T> extends Set<T> {
 	}
 
 	@Override
+	public MutableSet<T> getDistinct() {
+		return new MutableSet<>(store);
+	}
+
+	@Override
 	public MutableSet<T> unite(Set<T> set) {
 		final var items = super.unite(set);
 		return new MutableSet<>(items.store);

--- a/src/main/java/co/tsyba/core/collections/Set.java
+++ b/src/main/java/co/tsyba/core/collections/Set.java
@@ -77,6 +77,11 @@ public class Set<T> implements Collection<T> {
 		return index > -1;
 	}
 
+	@Override
+	public Set<T> getDistinct() {
+		return this;
+	}
+
 	/**
 	 * Returns {@code true} when this set is disjoint from the specified one; returns
 	 * {@code false} otherwise.

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -49,40 +49,115 @@ public class CollectionTests {
 	}
 
 	@DisplayName(".getMinimum(Comparator<T>)")
-	@Tests({
-		"when collection is not empty, returns minimum;" +
-			"[b, L, P, g, V, c];" +
-			"L",
-		"when collection is empty, returns empty optional;" +
-			"[];" +
-			"null"
-	})
-	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-	void testGetMin(@StringCollection Collection<String> items,
-		@StringOptional Optional<String> expected) {
-		final var minimum = items.getMin(Comparator.naturalOrder());
-		assertEquals(expected, minimum,
-			format("%s.getMinimum()", items));
+	@Nested
+	class GetMinComparatorTests {
+		@DisplayName("\uD83D\uDDFF")
+		@Tests({
+			"when collection is not empty, returns minimum;" +
+				"[b, L, P, g, V, c];" +
+				"L",
+			"when collection is empty, returns empty optional;" +
+				"[];" +
+				"null"
+		})
+		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+		void testGetMin(@StringCollection Collection<String> items,
+			@StringOptional Optional<String> expected) {
+			final var minimum = items.getMin(Comparator.naturalOrder());
+			assertEquals(expected, minimum,
+				format("%s.getMinimum()", items));
+		}
 	}
 
-	@DisplayName(".getMaximum(Comparator<T>)")
-	@Tests({
-		"when collection is not empty, returns maximum;" +
-			"[b, L, P, g, V, c];" +
-			"g",
-		"when collection is empty, returns empty optional;" +
-			"[];" +
-			"null"
-	})
+	@DisplayName(".getMin()")
+	@Nested
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-	void testGetMax(@StringCollection Collection<String> items,
-		@StringOptional Optional<String> expected) {
+	class GetMinTests {
+		@DisplayName("when items are comparable")
+		@Tests({
+			"when collection is not empty, returns minimum;" +
+				"[g, m, t, E, d, A, s];" +
+				"A",
+			"when collection is empty, returns empty optional;" +
+				"[];" +
+				"null"
+		})
+		void testComparable(@StringCollection Collection<String> items,
+			@StringOptional Optional<String> expected) {
 
-		final var maximum = items.getMax(Comparator.naturalOrder());
-		assertEquals(expected, maximum,
-			format("%s.getMaximum()", items));
+			final var min = items.getMin();
+			assertEquals(expected, min,
+				format("%s.getMin()", items));
+		}
+
+		@DisplayName("when items are not comparable")
+		@Tests({
+			"fails with UnsupportedOperationException"
+		})
+		void testNotComparable() {
+			assertThrows(UnsupportedOperationException.class,
+				() -> {
+					new PredicateCollection<>()
+						.getMin();
+				});
+		}
 	}
 
+	@DisplayName(".getMax(Comparator<T>)")
+	@Nested
+	class GetMaxComparatorTests {
+		@DisplayName("\uD83D\uDDBC")
+		@Tests({
+			"when collection is not empty, returns maximum;" +
+				"[b, L, P, g, V, c];" +
+				"g",
+			"when collection is empty, returns empty optional;" +
+				"[];" +
+				"null"
+		})
+		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+		void test(@StringCollection Collection<String> items,
+			@StringOptional Optional<String> expected) {
+
+			final var maximum = items.getMax(Comparator.naturalOrder());
+			assertEquals(expected, maximum,
+				format("%s.getMaximum()", items));
+		}
+	}
+
+	@DisplayName(".getMax()")
+	@Nested
+	class GetMaxTests {
+		@DisplayName("when items are comparable")
+		@Tests({
+			"when collection is not empty, returns maximum;" +
+				"[g, m, t, E, d, A, s];" +
+				"t",
+			"when collection is empty, returns empty optional;" +
+				"[];" +
+				"null"
+		})
+		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+		void testComparable(@StringCollection Collection<String> items,
+			@StringOptional Optional<String> expected) {
+
+			final var max = items.getMax();
+			assertEquals(expected, max,
+				format("%s.getMax()", items));
+		}
+
+		@DisplayName("when items are not comparable")
+		@Tests({
+			"fails with UnsupportedOperationException"
+		})
+		void testNotComparable() {
+			assertThrows(UnsupportedOperationException.class,
+				() -> {
+					new PredicateCollection<>()
+						.getMax();
+				});
+		}
+	}
 
 	@DisplayName(".contains(T)")
 	@Nested

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -58,9 +58,9 @@ public class CollectionTests {
 			"null"
 	})
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-	void testGetMinimum(@StringCollection Collection<String> items,
+	void testGetMin(@StringCollection Collection<String> items,
 		@StringOptional Optional<String> expected) {
-		final var minimum = items.getMinimum(Comparator.naturalOrder());
+		final var minimum = items.getMin(Comparator.naturalOrder());
 		assertEquals(expected, minimum,
 			format("%s.getMinimum()", items));
 	}
@@ -75,10 +75,10 @@ public class CollectionTests {
 			"null"
 	})
 	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-	void testGetMaximum(@StringCollection Collection<String> items,
+	void testGetMax(@StringCollection Collection<String> items,
 		@StringOptional Optional<String> expected) {
 
-		final var maximum = items.getMaximum(Comparator.naturalOrder());
+		final var maximum = items.getMax(Comparator.naturalOrder());
 		assertEquals(expected, maximum,
 			format("%s.getMaximum()", items));
 	}

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -19,51 +19,60 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CollectionTests {
 	@DisplayName(".isEmpty()")
-	@Tests({
-		"when collection is not empty, returns false;" +
-			"[f, T, q, r];" +
-			"false",
-		"when collection is empty, returns true;" +
-			"[];" +
-			"true"
-	})
-	void testIsEmpty(@StringCollection Collection<?> items, boolean expected) {
-		final var empty = items.isEmpty();
-		assertEquals(expected, empty,
-			format("%s.isEmpty()", items));
+	@Nested
+	class IsEmptyTests {
+		@DisplayName("\uD83C\uDFD4")
+		@Tests({
+			"when collection is not empty, returns false;" +
+				"[f, T, q, r];" +
+				"false",
+			"when collection is empty, returns true;" +
+				"[];" +
+				"true"
+		})
+		void test(@StringCollection Collection<String> items, boolean expected) {
+			final var empty = items.isEmpty();
+			assertEquals(expected, empty,
+				format("%s.isEmpty()", items));
+		}
 	}
 
 	@DisplayName(".getCount()")
-	@Tests({
-		"when collection is not empty, returns item count;" +
-			"[b, 5, F, e];" +
-			"4",
-		"when collection is empty, returns 0;" +
-			"[];" +
-			"0"
-	})
-	void testGetCount(@StringCollection Collection<?> items, int expected) {
-		final var count = items.getCount();
-		assertEquals(expected, count,
-			format("%s.getCount()", items));
+	@Nested
+	class GetCountTests {
+		@Tests({
+			"when collection is not empty, returns item count;" +
+				"[b, 5, F, e];" +
+				"4",
+			"when collection is empty, returns 0;" +
+				"[];" +
+				"0"
+		})
+		void test(@StringCollection Collection<?> items, int expected) {
+			final var count = items.getCount();
+			assertEquals(expected, count,
+				format("%s.getCount()", items));
+		}
 	}
 
-	@DisplayName(".getMinimum(Comparator<T>)")
+
+	@DisplayName(".getMin(Comparator<T>)")
 	@Nested
 	class GetMinComparatorTests {
 		@DisplayName("\uD83D\uDDFF")
 		@Tests({
 			"when collection is not empty, returns minimum;" +
 				"[b, L, P, g, V, c];" +
-				"L",
+				"g",
 			"when collection is empty, returns empty optional;" +
 				"[];" +
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void testGetMin(@StringCollection Collection<String> items,
+		void test(@StringCollection Collection<String> items,
 			@StringOptional Optional<String> expected) {
-			final var minimum = items.getMin(Comparator.naturalOrder());
+
+			final var minimum = items.getMin(Comparator.reverseOrder());
 			assertEquals(expected, minimum,
 				format("%s.getMinimum()", items));
 		}
@@ -110,7 +119,7 @@ public class CollectionTests {
 		@Tests({
 			"when collection is not empty, returns maximum;" +
 				"[b, L, P, g, V, c];" +
-				"g",
+				"L",
 			"when collection is empty, returns empty optional;" +
 				"[];" +
 				"null"
@@ -119,7 +128,7 @@ public class CollectionTests {
 		void test(@StringCollection Collection<String> items,
 			@StringOptional Optional<String> expected) {
 
-			final var maximum = items.getMax(Comparator.naturalOrder());
+			final var maximum = items.getMax(Comparator.reverseOrder());
 			assertEquals(expected, maximum,
 				format("%s.getMaximum()", items));
 		}
@@ -162,7 +171,7 @@ public class CollectionTests {
 	@DisplayName(".contains(T)")
 	@Nested
 	class ContainsTests {
-		@DisplayName("when collection is not empty")
+		@DisplayName("\uD83D\uDC8A")
 		@Tests({
 			"when item is present, returns true;" +
 				"[t, d, 5, V, A]; 5;" +
@@ -172,25 +181,14 @@ public class CollectionTests {
 				"false",
 			"when item is null, returns false;" +
 				"[t, d, 5, V, A]; null;" +
-				"false"
-		})
-		void testNotEmpty(@StringCollection Collection<String> items, String item,
-			boolean expected) {
-			test(items, item, expected);
-		}
-
-		@DisplayName("when collection is empty")
-		@Tests({
+				"false",
 			"when collection is empty, returns false;" +
 				"[]; 5;" +
-				"false",
+				"false"
 		})
-		void testEmpty(@StringCollection Collection<String> items, String item,
+		void test(@StringCollection Collection<String> items, String item,
 			boolean expected) {
-			test(items, item, expected);
-		}
 
-		private void test(Collection<String> items, String item, boolean expected) {
 			final var contains = items.contains(item);
 			assertEquals(expected, contains,
 				format("%s.contains(%s)", items, item));
@@ -358,57 +356,65 @@ public class CollectionTests {
 	}
 
 	@DisplayName(".sort(Comparator<T>)")
-	@Tests({
-		"when collection is not empty, returns sorted list;" +
-			"[k, M, s, A, 8, d, q];" +
-			"[s, q, k, d, M, A, 8]",
-		"when collection is empty, returns empty list;" +
-			"[];" +
-			"[]"
-	})
-	void testSortComparator(@StringCollection Collection<String> items,
-		@StringList List<String> expected) {
+	@Nested
+	class SortComparatorTests {
+		@DisplayName("\uD83C\uDFB3")
+		@Tests({
+			"when collection is not empty, returns sorted list;" +
+				"[k, M, s, A, 8, d, q];" +
+				"[s, q, k, d, M, A, 8]",
+			"when collection is empty, returns empty list;" +
+				"[];" +
+				"[]"
+		})
+		void test(@StringCollection Collection<String> items,
+			@StringList List<String> expected) {
 
-		final var sorted = items.sort(Comparator.reverseOrder());
-		assertEquals(expected, sorted,
-			format("%s.sort(Comparator<T>)", items));
+			final var sorted = items.sort(Comparator.reverseOrder());
+			assertEquals(expected, sorted,
+				format("%s.sort(Comparator<T>)", items));
+		}
 	}
 
 	@DisplayName(".sort()")
-	@Tests(value = {
-		"when collection is not empty, returns sorted list;" +
-			"[k, M, s, A, 8, d, q];" +
-			"[8, A, M, d, k, q, s]",
-		"when collection is empty, returns empty list;" +
-			"[];" +
-			"[]"
-	})
-	void testSort(@StringCollection Collection<String> items,
-		@StringList List<String> expected) {
+	@Nested
+	class SortTests {
+		@DisplayName("when items are comparable")
+		@Tests(value = {
+			"when collection is not empty, returns sorted list;" +
+				"[k, M, s, A, 8, d, q];" +
+				"[8, A, M, d, k, q, s]",
+			"when collection is empty, returns empty list;" +
+				"[];" +
+				"[]"
+		})
+		void testComparable(@StringCollection Collection<String> items,
+			@StringList List<String> expected) {
 
-		final var sorted = items.sort();
-		Assertions.assertEquals(expected, sorted,
-			format("%s.sort()", items));
-	}
+			final var sorted = items.sort();
+			Assertions.assertEquals(expected, sorted,
+				format("%s.sort()", items));
+		}
 
-	@DisplayName(".sort(), where T not Comparable")
-	@Test
-	void testSortNotComparable() {
-		Assertions.assertThrows(RuntimeException.class, () -> {
-			final var collection = new PredicateCollection<>(
-				String::isEmpty,
-				String::isBlank);
+		@DisplayName("when items are not comparable")
+		@Test
+		void testSortNotComparable() {
+			Assertions.assertThrows(RuntimeException.class, () -> {
+				final var collection = new PredicateCollection<>(
+					String::isEmpty,
+					String::isBlank);
 
-			collection.sort();
-		}, "<non comparable items>.sort()");
+				collection.sort();
+			}, "<non comparable items>.sort()");
+		}
 	}
 
 	@DisplayName(".shuffle(Random)")
 	@Nested
-	class TestShuffleRandom {
+	class ShuffleRandomTests {
 		@Test
 		@DisplayName("when collection is not empty, returns shuffled list")
-		void testWhenNotEmpty() {
+		void testNotEmpty() {
 			Collection<String> items = new ArrayCollection<>(
 				"r", "E", "V", "s", "x", "w", "O", "8");
 
@@ -428,7 +434,7 @@ public class CollectionTests {
 
 		@DisplayName("when collection is empty, returns empty list")
 		@Test
-		void testWhenEmpty() {
+		void testEmpty() {
 			final var items = new ArrayCollection<>();
 			final var time = System.currentTimeMillis();
 			final var random = new Random(time);
@@ -443,10 +449,10 @@ public class CollectionTests {
 
 	@DisplayName(".shuffle()")
 	@Nested
-	class TestShuffle {
+	class ShuffleTests {
 		@Test
 		@DisplayName("when collection is not empty, returns shuffled list")
-		void testWhenNotEmpty() {
+		void testNotEmpty() {
 			Collection<String> items = new ArrayCollection<>(
 				"o", "M", "F", "0", "K", "z", "v", "S");
 
@@ -461,7 +467,7 @@ public class CollectionTests {
 
 		@DisplayName("when collection is empty, returns empty list")
 		@Test
-		void testWhenEmpty() {
+		void testEmpty() {
 			final var items = new ArrayCollection<>();
 
 			final var shuffled = items.shuffle();
@@ -472,115 +478,131 @@ public class CollectionTests {
 		}
 	}
 
-	@DisplayName(".iterate(Consumer<T>)")
-	@Tests({
-		"when collection is not empty, iterates items;" +
-			"[f, F, e, q, p, L];" +
-			"[f, F, e, q, p, L]",
-		"when collection is empty, does nothing;" +
-			"[];" +
-			"[]"
-	})
-	void testIterate(@StringCollection Collection<String> items,
-		@StringArray String[] expected) {
+	static void assertShuffled(Collection<String> shuffled,
+		Collection<String> unshuffled, String message) {
 
-		final var iterated = new ArrayList<String>();
-		items.iterate(iterated::add);
-
-		assertArrayEquals(expected,
-			iterated.toArray(new String[]{}),
-			format("%s.iterate(Consumer<T>)", items));
-	}
-
-	@DisplayName(".combine(R, BiFunction<R, T, R>)")
-	@Tests({
-		"when collection is not empty, combines items with initial value;" +
-			"[g, E, Q, s, a, B]; B;" +
-			"BgEQsaB",
-		"when collection is empty, returns initial value;" +
-			"[]; A;" +
-			"A"
-	})
-	void testCombine(@StringCollection Collection<String> items, String initial,
-		String expected) {
-
-		final var combined = items.combine(initial,
-			(combined2, item) -> {
-				return combined2 + item;
-			});
-
-		assertEquals(expected, combined,
-			format("%s.combine(%s, BiFunction<R, T, R>)", items, initial));
-	}
-
-	@DisplayName(".join(String)")
-	@Tests({
-		"when collection is not empty, joins items into a string;" +
-			"[g, t, W, q, P, l]; -;" +
-			"g-t-W-q-P-l",
-		"when collection is empty, returns empty string;" +
-			"[]; -;" +
-			"null"
-	})
-	void testJoin(@StringCollection Collection<String> items, String separator,
-		String expected) {
-
-		if (expected == null) {
-			expected = "";
-		}
-
-		final var joined = items.join(separator);
-		assertEquals(expected, joined,
-			format("%s.join(%s)", items, separator));
-	}
-
-	@DisplayName(".toArray()")
-	@Tests({
-		"when collection is not empty, returns items array;" +
-			"[T, b, 4, 0, O];" +
-			"[T, b, 4, 0, O]",
-		"when collection is empty, returns empty array;" +
-			"[];" +
-			"[]"
-	})
-	void testToArray(@StringCollection Collection<String> items,
-		@StringArray String[] expected) {
-
-		final var array = items.toArray();
-		assertArrayEquals(expected, array,
-			format("%s.toArray()", items));
-	}
-
-	@DisplayName(".toArray(Class<? extends T[]>)")
-	@Tests({
-		"when collection is not empty, returns items array;" +
-			"[V, b, Q, r, 4, p];" +
-			"[V, b, Q, r, 4, p]",
-		"when collection is empty, returns empty array;" +
-			"[];" +
-			"[]"
-	})
-	void testToArrayClass(@StringCollection Collection<String> items,
-		@StringArray String[] expected) {
-
-		final var array = items.toArray(String[].class);
-		assertArrayEquals(expected, array,
-			format("%s.toArray(Class<? extends T[]>)", items));
-	}
-
-	static void assertShuffled
-		(Collection<String> shuffled, Collection<String> unshuffled, String message) {
 		final var items1 = shuffled.toArray(String[].class);
 		final var items2 = unshuffled.toArray(String[].class);
-		assertArrayNotEquals(items1, items2);
+		assertFalse(Arrays.equals(items1, items2), message);
 
 		Arrays.sort(items1);
 		Arrays.sort(items2);
 		assertArrayEquals(items1, items2, message);
 	}
 
-	static <T> void assertArrayNotEquals(T[] items1, T[] items2) {
-		assertFalse(Arrays.equals(items1, items2));
+	@DisplayName(".iterate(Consumer<T>)")
+	@Nested
+	class IterateTests {
+		@DisplayName("\uD83D\uDCE5")
+		@Tests({
+			"when collection is not empty, iterates items;" +
+				"[f, F, e, q, p, L];" +
+				"[f, F, e, q, p, L]",
+			"when collection is empty, does nothing;" +
+				"[];" +
+				"[]"
+		})
+		void test(@StringCollection Collection<String> items,
+			@StringArray String[] expected) {
+
+			final var iterated = new ArrayList<String>();
+			items.iterate(iterated::add);
+
+			assertArrayEquals(expected,
+				iterated.toArray(new String[]{}),
+				format("%s.iterate(Consumer<T>)", items));
+		}
+	}
+
+	@DisplayName(".combine(R, BiFunction<R, T, R>)")
+	@Nested
+	class CombineTests {
+		@DisplayName("\uD83D\uDC53")
+		@Tests({
+			"when collection is not empty, combines items with initial value;" +
+				"[g, E, Q, s, a, B]; B;" +
+				"BgEQsaB",
+			"when collection is empty, returns initial value;" +
+				"[]; A;" +
+				"A"
+		})
+		void test(@StringCollection Collection<String> items, String initial,
+			String expected) {
+
+			final var combined = items.combine(initial,
+				(combined2, item) -> {
+					return combined2 + item;
+				});
+
+			assertEquals(expected, combined,
+				format("%s.combine(%s, BiFunction<R, T, R>)", items, initial));
+		}
+	}
+
+	@DisplayName(".join(String)")
+	@Nested
+	class JoinTests {
+		@DisplayName("\uD83C\uDFF0")
+		@Tests({
+			"when collection is not empty, joins items into a string;" +
+				"[g, t, W, q, P, l]; -;" +
+				"g-t-W-q-P-l",
+			"when collection is empty, returns empty string;" +
+				"[]; -;" +
+				"null"
+		})
+		void test(@StringCollection Collection<String> items, String separator,
+			String expected) {
+
+			if (expected == null) {
+				expected = "";
+			}
+
+			final var joined = items.join(separator);
+			assertEquals(expected, joined,
+				format("%s.join(%s)", items, separator));
+		}
+	}
+
+	@DisplayName(".toArray(Class<? extends T[]>)")
+	@Nested
+	class ToArrayClassTests {
+		@DisplayName("\uD83C\uDFE1")
+		@Tests({
+			"when collection is not empty, returns items array;" +
+				"[V, b, Q, r, 4, p];" +
+				"[V, b, Q, r, 4, p]",
+			"when collection is empty, returns empty array;" +
+				"[];" +
+				"[]"
+		})
+		void test(@StringCollection Collection<String> items,
+			@StringArray String[] expected) {
+
+			final var array = items.toArray(String[].class);
+			assertArrayEquals(expected, array,
+				format("%s.toArray(Class<? extends T[]>)", items));
+		}
+	}
+
+	@DisplayName(".toArray()")
+	@Nested
+	class ToArrayTests {
+		@Tests({
+			"when collection is not empty, returns items array;" +
+				"[T, b, 4, 0, O];" +
+				"[T, b, 4, 0, O]",
+			"when collection is empty, returns empty array;" +
+				"[];" +
+				"[]"
+		})
+		void test(@StringCollection Collection<String> items,
+			@StringArray String[] expected) {
+
+			final var array = items.toArray();
+			assertArrayEquals(expected, array,
+				format("%s.toArray()", items));
+		}
 	}
 }
 

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -241,50 +241,10 @@ public class CollectionTests {
 		}
 	}
 
-	@DisplayName(".match(Predicate<T>)")
-	@Nested
-	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-	class MatchTests {
-		@DisplayName("when collection is not empty")
-		@Tests({
-			"when some item matches, returns matched item;" +
-				"[F, V, d, P, a, Q];" +
-				"d",
-			"when no item matches, returns empty optional;" +
-				"[F, V, D, P, A, Q];" +
-				"null",
-		})
-		void testNotEmpty(@StringCollection Collection<String> items,
-			@StringOptional Optional<String> expected) {
-			test(items, expected);
-		}
-
-		@DisplayName("when collection is empty")
-		@Tests({
-			"returns empty optional;" +
-				"[];" +
-				"null"
-		})
-		void testEmpty(@StringCollection Collection<String> items,
-			@StringOptional Optional<String> expected) {
-			test(items, expected);
-		}
-
-		private void test(Collection<String> items, Optional<String> expected) {
-			final var match = items.match((item) -> {
-				return item.toLowerCase()
-					.equals(item);
-			});
-
-			assertEquals(expected, match,
-				format("%s.match(Predicate<T>)", items));
-		}
-	}
-
 	@DisplayName(".noneMatches(Predicate<T>)")
 	@Nested
 	class NoneMatchesTests {
-		@DisplayName("when collection is not empty")
+		@DisplayName("\uD83D\uDD2C")
 		@Tests({
 			"when no item matches, returns true;" +
 				"[K, M, T, S, A];" +
@@ -294,23 +254,12 @@ public class CollectionTests {
 				"false",
 			"when all items match, returns false;" +
 				"[k, m, t, s, a];" +
-				"false"
-		})
-		void testNotEmpty(@StringCollection Collection<String> items, boolean expected) {
-			test(items, expected);
-		}
-
-		@DisplayName("when collection is empty")
-		@Tests({
-			"returns true;" +
+				"false",
+			"when collection is empty, returns true;" +
 				"[];" +
-				"true",
+				"true"
 		})
-		void testEmpty(@StringCollection Collection<String> items, boolean expected) {
-			test(items, expected);
-		}
-
-		private void test(Collection<String> items, boolean expected) {
+		void test(@StringCollection Collection<String> items, boolean expected) {
 			final var matches = items.noneMatches((item) -> {
 				return item.toLowerCase()
 					.equals(item);
@@ -324,7 +273,7 @@ public class CollectionTests {
 	@DisplayName(".anyMatches(Predicate<T>)")
 	@Nested
 	class AnyMatchesTests {
-		@DisplayName("when collection is not empty")
+		@DisplayName("\uD83D\uDC20")
 		@Tests({
 			"when no item matches, returns false;" +
 				"[Y, P, D, A, S, M, S];" +
@@ -335,22 +284,11 @@ public class CollectionTests {
 			"when all items match, returns true;" +
 				"[y, p, d, a, s, m, s];" +
 				"true",
-		})
-		void testNotEmpty(@StringCollection Collection<String> items, boolean expected) {
-			test(items, expected);
-		}
-
-		@DisplayName("when collection is empty")
-		@Tests({
-			"returns false;" +
+			"when collection is empty, returns false;" +
 				"[];" +
 				"false",
 		})
-		void testEmpty(@StringCollection Collection<String> items, boolean expected) {
-			test(items, expected);
-		}
-
-		private void test(Collection<String> items, boolean expected) {
+		void test(@StringCollection Collection<String> items, boolean expected) {
 			final var matches = items.anyMatches((item) -> {
 				return item.toLowerCase()
 					.equals(item);
@@ -364,7 +302,7 @@ public class CollectionTests {
 	@DisplayName(".eachMatches(Predicate<T>)")
 	@Nested
 	class EachMatchesTests {
-		@DisplayName("when collection is not empty")
+		@DisplayName("\uD83D\uDD2A")
 		@Tests({
 			"when no item matches, returns false;" +
 				"[H, B, S, A];" +
@@ -375,22 +313,11 @@ public class CollectionTests {
 			"when each items match, returns true;" +
 				"[h, b, s, a];" +
 				"true",
-		})
-		void testNotEmpty(@StringCollection Collection<String> items, boolean expected) {
-			test(items, expected);
-		}
-
-		@DisplayName("when collection is empty")
-		@Tests({
-			"returns true;" +
+			"when collection is empty, returns true;" +
 				"[];" +
 				"true",
 		})
-		void testEmpty(@StringCollection Collection<String> items, boolean expected) {
-			test(items, expected);
-		}
-
-		private void test(Collection<String> items, boolean expected) {
+		void test(@StringCollection Collection<String> items, boolean expected) {
 			final var matches = items.eachMatches((item) -> {
 				return item.toLowerCase()
 					.equals(item);
@@ -398,6 +325,35 @@ public class CollectionTests {
 
 			assertEquals(expected, matches,
 				format("%s.eachMatches(Predicate<T>)", items));
+		}
+	}
+
+	@DisplayName(".matchAny(Predicate<T>)")
+	@Nested
+	@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+	class MatchAnyTests {
+		@DisplayName("\uD83C\uDF2D")
+		@Tests({
+			"when some item matches, returns matched item;" +
+				"[F, V, d, P, a, Q];" +
+				"d",
+			"when no item matches, returns empty optional;" +
+				"[F, V, D, P, A, Q];" +
+				"null",
+			"when collection is empty, returns empty optional;" +
+				"[];" +
+				"null"
+		})
+		void test(@StringCollection Collection<String> items,
+			@StringOptional Optional<String> expected) {
+
+			final var match = items.matchAny((item) -> {
+				return item.toLowerCase()
+					.equals(item);
+			});
+
+			assertEquals(expected, match,
+				format("%s.match(Predicate<T>)", items));
 		}
 	}
 
@@ -629,6 +585,26 @@ public class CollectionTests {
 }
 
 @Retention(RetentionPolicy.RUNTIME)
+@ConvertWith(StringCollection.Converter.class)
+@interface StringCollection {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, Collection> {
+		protected Converter() {
+			super(String.class, Collection.class);
+		}
+
+		@Override
+		protected Collection<String> convert(String s) throws ArgumentConversionException {
+			final var items = new StringArray.Converter()
+				.convert(s);
+
+			return new ArrayCollection<>(items) {
+			};
+		}
+	}
+}
+
+@Retention(RetentionPolicy.RUNTIME)
 @ConvertWith(StringArray.Converter.class)
 @interface StringArray {
 	class Converter extends TypedArgumentConverter<String, String[]> {
@@ -671,26 +647,6 @@ public class CollectionTests {
 		@Override
 		protected Optional<String> convert(String s) throws ArgumentConversionException {
 			return Optional.ofNullable(s);
-		}
-	}
-}
-
-@Retention(RetentionPolicy.RUNTIME)
-@ConvertWith(StringCollection.Converter.class)
-@interface StringCollection {
-	@SuppressWarnings("rawtypes")
-	class Converter extends TypedArgumentConverter<String, Collection> {
-		protected Converter() {
-			super(String.class, Collection.class);
-		}
-
-		@Override
-		protected Collection<String> convert(String s) throws ArgumentConversionException {
-			final var items = new StringArray.Converter()
-				.convert(s);
-
-			return new ArrayCollection<>(items) {
-			};
 		}
 	}
 }

--- a/src/test/java/co/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/co/tsyba/core/collections/CollectionTests.java
@@ -660,6 +660,11 @@ class ArrayCollection<T> implements Collection<T> {
 	}
 
 	@Override
+	public Collection<T> getDistinct() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public Collection<T> filter(Predicate<T> condition) {
 		throw new UnsupportedOperationException();
 	}
@@ -701,6 +706,11 @@ class PredicateCollection<T> implements Collection<Predicate<T>> {
 	@SafeVarargs
 	public PredicateCollection(Predicate<T>... items) {
 		this.items = items;
+	}
+
+	@Override
+	public Collection<Predicate<T>> getDistinct() {
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/src/test/java/co/tsyba/core/collections/IndexRangeTests.java
+++ b/src/test/java/co/tsyba/core/collections/IndexRangeTests.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class IndexRangeTests {
 	@DisplayName("IndexRange(int, int)")
@@ -618,6 +619,21 @@ class IndexRangeTests {
 			final var indexes = range.find(items);
 			assertEquals(expected, indexes,
 				format("%s.find(%s)", range, items));
+		}
+	}
+
+	@DisplayName(".getDistinct()")
+	@Nested
+	class GetDistinctTests {
+		@DisplayName("\uD83C\uDFC0")
+		@Tests({
+			"returns itself;" +
+				"[4, 9)"
+		})
+		void test(@IntRange IndexRange range) {
+			final var distinct = range.getDistinct();
+			assertSame(range, distinct,
+				format("%s.getDistinct()", range));
 		}
 	}
 

--- a/src/test/java/co/tsyba/core/collections/MutableSetTests.java
+++ b/src/test/java/co/tsyba/core/collections/MutableSetTests.java
@@ -1,6 +1,7 @@
 package co.tsyba.core.collections;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
 import org.junit.jupiter.params.converter.ConvertWith;
@@ -11,10 +12,27 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
+import static java.lang.String.format;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class MutableSetTests {
+	@DisplayName(".getDistinct()")
+	@Nested
+	class GetDistinctTests {
+		@DisplayName("")
+		@Tests({
+			"returns a copy of itself;" +
+				"[g, t, w, s, A, q]"
+		})
+		void test(@StringMutableSet MutableSet<String> items) {
+			final var distinct = items.getDistinct();
+			assertEquals(items, distinct,
+				format("%s.getDistinct()", items));
+			assertNotSame(items, distinct,
+				format("%s.getDistinct()", items));
+		}
+	}
+
 	@DisplayName(".unite(Set<T>)")
 	@ParameterizedTest(name = "{0}")
 	@CsvSource(value = {

--- a/src/test/java/co/tsyba/core/collections/SequenceTests.java
+++ b/src/test/java/co/tsyba/core/collections/SequenceTests.java
@@ -469,6 +469,11 @@ class ArraySequence<T> implements Sequence<T> {
 	}
 
 	@Override
+	public Collection<T> getDistinct() {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
 	public Sequence<T> filter(Predicate<T> condition) {
 		throw new UnsupportedOperationException();
 	}

--- a/src/test/java/co/tsyba/core/collections/SetTests.java
+++ b/src/test/java/co/tsyba/core/collections/SetTests.java
@@ -1,6 +1,7 @@
 package co.tsyba.core.collections;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
 import org.junit.jupiter.params.converter.ConvertWith;
@@ -11,7 +12,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Arrays;
 
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 public class SetTests {
 	@DisplayName("Set(Collection<T>)")
@@ -117,6 +120,21 @@ public class SetTests {
 
 		final var contains = items.contains(item);
 		assertEquals(expected, contains);
+	}
+
+	@DisplayName(".getDistinct()")
+	@Nested
+	class GetDistinctTests {
+		@DisplayName("\uD83D\uDCD7")
+		@Tests({
+			"returns itself;" +
+				"[g, t, w, s, A, q]"
+		})
+		void test(@StringSet Set<String> items) {
+			final var distinct = items.getDistinct();
+			assertSame(items, distinct,
+				format("%s.getDistinct()", items));
+		}
 	}
 
 	@DisplayName(".isDisjoint(Set<T>)")


### PR DESCRIPTION
This update adds the following changes to `Collection` interface:
- `getMinimum()` and `getMaximum()` are renamed into `getMin()` and `getMax()`
- `match(Predicate<T>)` is renamed to `matchAny(Predicate<T>)`
- `sort()` and `shuffle()` return instances of `Sequence<T>`, instead of `List<T>`
- `getDistinct()` is added

Additionally, this update refactors `Collection`'s unit tests.