### PR TITLE
Fix index-based operations in IndexRange.

### DIFF
--- a/src/main/java/com/tsyba/core/collections/IndexRange.java
+++ b/src/main/java/com/tsyba/core/collections/IndexRange.java
@@ -92,51 +92,55 @@ public class IndexRange implements Sequence<Integer> {
 
 	@Override
 	public Integer get(int index) {
-		if (!contains(index)) {
-			throw new IndexNotInRangeException(index, this);
+		final var range = getIndexRange();
+		if (!range.contains(index)) {
+			throw new IndexNotInRangeException(index, range);
 		}
 
-		return index;
+		return start + index;
 	}
 
 	@Override
 	public IndexRange getPrefix(int index) {
-		if (!contains(index)) {
-			throw new IndexNotInRangeException(index, this);
+		final var range = getIndexRange();
+		if (!range.contains(index)) {
+			throw new IndexNotInRangeException(index, range);
 		}
 
-		return new IndexRange(start, index);
+		return new IndexRange(start, start + index);
 	}
 
 	@Override
 	public IndexRange getSuffix(int index) {
-		if (!contains(index)) {
-			throw new IndexNotInRangeException(index, this);
+		final var range = getIndexRange();
+		if (!range.contains(index)) {
+			throw new IndexNotInRangeException(index, range);
 		}
 
-		return new IndexRange(index, end);
+		return new IndexRange(start + index, end);
 	}
 
 	@Override
 	public Sequence<Integer> get(IndexRange range) {
-		if (!contains(range)) {
-			throw new IndexRangeNotInRangeException(range, this);
+		final var validRange = getIndexRange();
+		if (!validRange.contains(range)) {
+			throw new IndexRangeNotInRangeException(range, validRange);
 		}
 
-		return range;
+		return new IndexRange(start + range.start, start + range.end);
 	}
 
 	@Override
 	public Optional<Integer> findFirst(Integer item) {
 		return contains(item)
-			? Optional.of(item)
+			? Optional.of(item - start)
 			: Optional.empty();
 	}
 
 	@Override
 	public Sequence<Integer> find(Integer item) {
 		return contains(item)
-			? new List<>(item)
+			? new List<>(item - start)
 			: new List<>();
 	}
 
@@ -212,21 +216,40 @@ public class IndexRange implements Sequence<Integer> {
 	}
 
 	@Override
-	public Iterator<Integer> iterator() {
+	public Iterator<Integer> iterator(int index) {
+		final var range = getIndexRange();
+		if (!range.contains(index)) {
+			throw new IndexNotInRangeException(index, range);
+		}
+
 		return new Iterator<>() {
-			private int index = start;
+			private int next = start + index;
 
 			@Override
 			public boolean hasNext() {
-				return index < end;
+				return next < end;
 			}
 
 			@Override
 			public Integer next() {
-				final var next = index;
-				index += 1;
+				return next++;
+			}
+		};
+	}
 
-				return next;
+	@Override
+	public Iterator<Integer> iterator() {
+		return new Iterator<>() {
+			private int next = start;
+
+			@Override
+			public boolean hasNext() {
+				return next < end;
+			}
+
+			@Override
+			public Integer next() {
+				return next++;
 			}
 		};
 	}

--- a/src/main/java/com/tsyba/core/collections/Sequence.java
+++ b/src/main/java/com/tsyba/core/collections/Sequence.java
@@ -178,8 +178,8 @@ public interface Sequence<T> extends Collection<T> {
 	 * sequence, unless this sequence is empty as well.
 	 */
 	default Optional<Integer> findFirst(Sequence<T> items) {
-		if (items.isEmpty()) {
-			return Optional.of(0);
+		if (isEmpty()) {
+			return Optional.empty();
 		}
 
 		final var range = getIndexRange();

--- a/src/main/java/com/tsyba/core/collections/Sequence.java
+++ b/src/main/java/com/tsyba/core/collections/Sequence.java
@@ -252,9 +252,4 @@ public interface Sequence<T> extends Collection<T> {
 	 * this sequence
 	 */
 	Iterator<T> iterator(int index);
-
-	@Override
-	default Iterator<T> iterator() {
-		return iterator(0);
-	}
 }

--- a/src/main/java/com/tsyba/core/collections/Sequence.java
+++ b/src/main/java/com/tsyba/core/collections/Sequence.java
@@ -157,9 +157,7 @@ public interface Sequence<T> extends Collection<T> {
 	 * sequence is empty, returns first valid index of this sequence.
 	 */
 	default Optional<Integer> findFirst(Predicate<T> condition) {
-		final var range = getIndexRange();
-		var index = range.start;
-
+		var index = 0;
 		for (var item : this) {
 			if (condition.test(item)) {
 				return Optional.of(index);
@@ -180,14 +178,11 @@ public interface Sequence<T> extends Collection<T> {
 	 * sequence, unless this sequence is empty as well.
 	 */
 	default Optional<Integer> findFirst(Sequence<T> items) {
-		final var range = getIndexRange();
-		if (range.isEmpty()) {
-			return Optional.empty();
-		}
 		if (items.isEmpty()) {
-			return Optional.of(range.start);
+			return Optional.of(0);
 		}
 
+		final var range = getIndexRange();
 		search:
 		for (var index : range) {
 			final var iterator1 = items.iterator();
@@ -250,20 +245,16 @@ public interface Sequence<T> extends Collection<T> {
 	@Override
 	<R> Sequence<R> convert(Function<T, R> converter);
 
-	default Iterator<T> iterator(int index) {
-		final var range = getIndexRange();
-		if (!range.contains(index)) {
-			throw new IndexNotInRangeException(index, range);
-		}
+	/**
+	 * Returns {@link Iterator}, which starts with item at the specified index.
+	 *
+	 * @throws IndexNotInRangeException when the specified index is out of valid range of
+	 * this sequence
+	 */
+	Iterator<T> iterator(int index);
 
-		final var iterator = iterator();
-		var index2 = range.start;
-
-		while (index2 < index) {
-			iterator.next();
-			++index2;
-		}
-
-		return iterator;
+	@Override
+	default Iterator<T> iterator() {
+		return iterator(0);
 	}
 }

--- a/src/main/java/com/tsyba/core/collections/Sequence.java
+++ b/src/main/java/com/tsyba/core/collections/Sequence.java
@@ -251,5 +251,20 @@ public interface Sequence<T> extends Collection<T> {
 	 * @throws IndexNotInRangeException when the specified index is out of valid range of
 	 * this sequence
 	 */
-	Iterator<T> iterator(int index);
+	default Iterator<T> iterator(int index) {
+		final var range = getIndexRange();
+		if (!range.contains(index)) {
+			throw new IndexNotInRangeException(index, range);
+		}
+
+		final var iterator = iterator();
+		var skip = 0;
+
+		while (skip < index) {
+			iterator.next();
+			++skip;
+		}
+
+		return iterator;
+	}
 }

--- a/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
+++ b/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
@@ -35,7 +35,7 @@ class IndexRangeTests {
 				"-4; 4;" +
 				"null"
 		})
-		void test(int start, int end, @IntRange IndexRange expected) {
+		void test(int start, int end, @TestRange IndexRange expected) {
 			try {
 				final var range = new IndexRange(start, end);
 				assertEquals(expected, range,
@@ -56,7 +56,7 @@ class IndexRangeTests {
 			"creates empty index range;" +
 				"[0, 0)"
 		})
-		void test(@IntRange IndexRange expected) {
+		void test(@TestRange IndexRange expected) {
 			final var range = new IndexRange();
 			assertEquals(expected, range,
 				"new IndexRange()");
@@ -75,7 +75,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"0"
 		})
-		void test(@IntRange IndexRange range, int expected) {
+		void test(@TestRange IndexRange range, int expected) {
 			final var count = range.getCount();
 			assertEquals(expected, count,
 				format("%s.isEmpty()", range));
@@ -94,7 +94,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"[0, 0)"
 		})
-		void test(@IntRange IndexRange range, @IntRange IndexRange expected) {
+		void test(@TestRange IndexRange range, @TestRange IndexRange expected) {
 			final var returned = range.getIndexRange();
 			assertEquals(expected, returned,
 				format("%s.getIndexRange()", range));
@@ -125,7 +125,7 @@ class IndexRangeTests {
 				"[4, 8); null;" +
 				"false"
 		})
-		void testNotEmpty(@IntRange IndexRange range, Integer index, boolean expected) {
+		void testNotEmpty(@TestRange IndexRange range, Integer index, boolean expected) {
 			test(range, index, expected);
 		}
 
@@ -144,7 +144,7 @@ class IndexRangeTests {
 				"[0, 0); null;" +
 				"false"
 		})
-		void testEmpty(@IntRange IndexRange range, Integer index, boolean expected) {
+		void testEmpty(@TestRange IndexRange range, Integer index, boolean expected) {
 			test(range, index, expected);
 		}
 
@@ -182,7 +182,7 @@ class IndexRangeTests {
 				"[6, 9); [0, 0);" +
 				"true"
 		})
-		void testNotEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
+		void testNotEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
 			boolean expected) {
 			test(range1, range2, expected);
 		}
@@ -196,7 +196,7 @@ class IndexRangeTests {
 				"[0, 0); [0, 0);" +
 				"true"
 		})
-		void testEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
+		void testEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
 			boolean expected) {
 			test(range1, range2, expected);
 		}
@@ -221,7 +221,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"null"
 		})
-		void test(@IntRange IndexRange range, @IntOptional Optional<Integer> expected) {
+		void test(@TestRange IndexRange range, @IntOptional Optional<Integer> expected) {
 			final var first = range.getFirst();
 			assertEquals(expected, first,
 				format("%s.getFirst()", range));
@@ -241,7 +241,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"null"
 		})
-		void test(@IntRange IndexRange range, @IntOptional Optional<Integer> expected) {
+		void test(@TestRange IndexRange range, @IntOptional Optional<Integer> expected) {
 			final var first = range.getLast();
 			assertEquals(expected, first,
 				format("%s.getLast()", range));
@@ -270,7 +270,7 @@ class IndexRangeTests {
 				"[4, 8); 9;" +
 				"null; 9 ∉ [0, 4)"
 		})
-		void testNotEmpty(@IntRange IndexRange range, int index, Integer expected1,
+		void testNotEmpty(@TestRange IndexRange range, int index, Integer expected1,
 			@IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
@@ -287,7 +287,7 @@ class IndexRangeTests {
 				"[0, 0); 1;" +
 				"null; 1 ∉ [0, 0)",
 		})
-		void testEmpty(@IntRange IndexRange range, int index, Integer expected1,
+		void testEmpty(@TestRange IndexRange range, int index, Integer expected1,
 			@IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
@@ -331,8 +331,8 @@ class IndexRangeTests {
 				"[2, 9); 12;" +
 				"null; 12 ∉ [0, 7)",
 		})
-		void testNotEmpty(@IntRange IndexRange range, int index,
-			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testNotEmpty(@TestRange IndexRange range, int index,
+			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
 
@@ -348,8 +348,8 @@ class IndexRangeTests {
 				"[0, 0); 1;" +
 				"null; 1 ∉ [0, 0)",
 		})
-		void testEmpty(@IntRange IndexRange range, int index,
-			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testEmpty(@TestRange IndexRange range, int index,
+			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
 
@@ -392,8 +392,8 @@ class IndexRangeTests {
 				"[2, 9); 12;" +
 				"null; 12 ∉ [0, 7)",
 		})
-		void testNotEmpty(@IntRange IndexRange range, int index,
-			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testNotEmpty(@TestRange IndexRange range, int index,
+			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
 
@@ -409,8 +409,8 @@ class IndexRangeTests {
 				"[0, 0); 1;" +
 				"null; 1 ∉ [0, 0)",
 		})
-		void testEmpty(@IntRange IndexRange range, int index,
-			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testEmpty(@TestRange IndexRange range, int index,
+			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
 
@@ -453,8 +453,8 @@ class IndexRangeTests {
 				"[6, 9); [0, 0);" +
 				"[0, 0); null"
 		})
-		void testNotEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
-			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testNotEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
+			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range1, range2, expected1, expected2);
 		}
 
@@ -467,8 +467,8 @@ class IndexRangeTests {
 				"[0, 0); [0, 0);" +
 				"[0, 0); null"
 		})
-		void testEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
-			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
+			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range1, range2, expected1, expected2);
 		}
 
@@ -515,7 +515,7 @@ class IndexRangeTests {
 				"[0, 0); 0;" +
 				"null"
 		})
-		void test(@IntRange IndexRange range, int item,
+		void test(@TestRange IndexRange range, int item,
 			@IntOptional Optional<Integer> expected) {
 
 			final var index = range.findFirst(item);
@@ -548,7 +548,7 @@ class IndexRangeTests {
 				"[4, 9); null;" +
 				"[]"
 		})
-		void testNotEmpty(@IntRange IndexRange range, Integer index,
+		void testNotEmpty(@TestRange IndexRange range, Integer index,
 			@IntList List<Integer> expected) {
 			test(range, index, expected);
 		}
@@ -568,7 +568,7 @@ class IndexRangeTests {
 				"[0, 0); null;" +
 				"[]"
 		})
-		void testEmpty(@IntRange IndexRange range, Integer index,
+		void testEmpty(@TestRange IndexRange range, Integer index,
 			@IntList List<Integer> expected) {
 			test(range, index, expected);
 		}
@@ -598,7 +598,7 @@ class IndexRangeTests {
 				"[3, 9); [];" +
 				"[0, 1, 2, 3, 4, 5]"
 		})
-		void testNotEmpty(@IntRange IndexRange range, @IntList List<Integer> items,
+		void testNotEmpty(@TestRange IndexRange range, @IntList List<Integer> items,
 			@IntList List<Integer> expected) {
 			test(range, items, expected);
 		}
@@ -612,7 +612,7 @@ class IndexRangeTests {
 				"[0, 0); [];" +
 				"[]"
 		})
-		void testEmpty(@IntRange IndexRange range, @IntList List<Integer> items,
+		void testEmpty(@TestRange IndexRange range, @IntList List<Integer> items,
 			@IntList List<Integer> expected) {
 			test(range, items, expected);
 		}
@@ -634,7 +634,7 @@ class IndexRangeTests {
 			"returns itself;" +
 				"[4, 9)"
 		})
-		void test(@IntRange IndexRange range) {
+		void test(@TestRange IndexRange range) {
 			final var distinct = range.getDistinct();
 			assertSame(range, distinct,
 				format("%s.getDistinct()", range));
@@ -653,7 +653,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"[]"
 		})
-		void test(@IntRange IndexRange range, @IntList List<Integer> expected) {
+		void test(@TestRange IndexRange range, @IntList List<Integer> expected) {
 			final var matches = range.filter((index) -> index % 2 == 0);
 			assertEquals(expected, matches,
 				format("%s.filter(<is even>)", range));
@@ -678,7 +678,7 @@ class IndexRangeTests {
 				"[4, 8); null;" +
 				"false"
 		})
-		void testNotEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
+		void testNotEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
 			boolean expected) {
 			test(range1, range2, expected);
 		}
@@ -695,7 +695,7 @@ class IndexRangeTests {
 				"[0, 0); null;" +
 				"false"
 		})
-		void testEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
+		void testEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
 			boolean expected) {
 			test(range1, range2, expected);
 		}
@@ -728,7 +728,7 @@ class IndexRangeTests {
 				"[2, 6); 9;" +
 				"null; 9 ∉ [0, 4)"
 		})
-		void testNotEmpty(@IntRange IndexRange range, int index,
+		void testNotEmpty(@TestRange IndexRange range, int index,
 			@StringList List<String> expected1,
 			@IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
@@ -746,7 +746,7 @@ class IndexRangeTests {
 				"[0, 0); 1;" +
 				"null; 1 ∉ [0, 0)"
 		})
-		void testEmpty(@IntRange IndexRange range, int index,
+		void testEmpty(@TestRange IndexRange range, int index,
 			@StringList List<String> expected1,
 			@IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
@@ -788,7 +788,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"[]"
 		})
-		void test(@IntRange IndexRange range, @StringList List<String> expected) {
+		void test(@TestRange IndexRange range, @StringList List<String> expected) {
 			final var iterator = range.iterator();
 			final var iterated = new MutableList<String>();
 			while (iterator.hasNext()) {
@@ -813,7 +813,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"[0, 0)"
 		})
-		void test(@IntRange IndexRange range, String expected) {
+		void test(@TestRange IndexRange range, String expected) {
 			final var string = range.toString();
 			assertEquals(expected, string,
 				format("%s.toString()", range));
@@ -822,8 +822,8 @@ class IndexRangeTests {
 }
 
 @Retention(RetentionPolicy.RUNTIME)
-@ConvertWith(IntRange.Converter.class)
-@interface IntRange {
+@ConvertWith(TestRange.Converter.class)
+@interface TestRange {
 	class Converter extends TypedArgumentConverter<String, IndexRange> {
 		protected Converter() {
 			super(String.class, IndexRange.class);
@@ -846,9 +846,9 @@ class IndexRangeTests {
 	}
 }
 
-@ConvertWith(IntRangeOptional.Converter.class)
+@ConvertWith(TestRangeOptional.Converter.class)
 @Retention(RetentionPolicy.RUNTIME)
-@interface IntRangeOptional {
+@interface TestRangeOptional {
 	@SuppressWarnings("rawtypes")
 	class Converter extends TypedArgumentConverter<String, Optional> {
 		protected Converter() {
@@ -857,7 +857,7 @@ class IndexRangeTests {
 
 		@Override
 		protected Optional<IndexRange> convert(String s) throws ArgumentConversionException {
-			final var converter = new IntRange.Converter();
+			final var converter = new TestRange.Converter();
 			return Optional.ofNullable(s)
 				.map(converter::convert);
 		}

--- a/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
+++ b/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.params.converter.TypedArgumentConverter;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -158,22 +160,22 @@ class IndexRangeTests {
 	class ContainsIndexRange {
 		@DisplayName("when range is not empty")
 		@Tests({
-			"when argument range is before range, returns false;" +
+			"when argument range starts and ends before range start, returns false;" +
 				"[6, 9); [1, 4);" +
 				"false",
-			"when argument range starts before range, returns false;" +
+			"when argument range starts before range start and ends within range, returns false;" +
 				"[6, 9); [4, 7);" +
 				"false",
-			"when argument range starts at range start, returns true;" +
+			"when argument range starts at range start and ends within range, returns true;" +
 				"[6, 9); [6, 8);" +
 				"true",
-			"when argument range equals range, returns true;" +
+			"when argument range coincides with range, returns true;" +
 				"[6, 9); [6, 9);" +
 				"true",
-			"when argument range ends after range, returns false;" +
+			"when argument range starts within range ends after range end, returns false;" +
 				"[6, 9); [7, 11);" +
 				"false",
-			"when argument range is after range, returns false;" +
+			"when argument range starts and ends after range end, returns false;" +
 				"[6, 9); [12, 17);" +
 				"false",
 			"when argument range is empty, returns true;" +
@@ -249,57 +251,60 @@ class IndexRangeTests {
 
 	@DisplayName(".get(Integer)")
 	@Nested
-	class TestGet {
+	class GetTests {
 		@DisplayName("when range is not empty")
 		@Tests({
-			"when index is before range start, fails;" +
+			"when index is before valid index range start, fails;" +
+				"[4, 8); -4;" +
+				"null; -4 ∉ [0, 4)",
+			"when index is at valid index range start, returns index;" +
+				"[4, 8); 0;" +
+				"4; null",
+			"when index is within valid index range, returns index;" +
 				"[4, 8); 2;" +
-				"null",
-			"when index is at range start, returns index;" +
+				"6; null",
+			"when index is at valid index range end, fails;" +
 				"[4, 8); 4;" +
-				"4",
-			"when index is within range, returns index;" +
-				"[4, 8); 6;" +
-				"6",
-			"when index is at range end, fails;" +
-				"[4, 8); 8;" +
-				"null",
-			"when index is after range end, fails;" +
+				"null; 4 ∉ [0, 4)",
+			"when index is after valid index range end, fails;" +
 				"[4, 8); 9;" +
-				"null"
+				"null; 9 ∉ [0, 4)"
 		})
-		void testNotEmpty(@IntRange IndexRange range, int index, Integer expected) {
-			test(range, index, expected);
+		void testNotEmpty(@IntRange IndexRange range, int index, Integer expected1,
+			@IndexRangeException Exception expected2) {
+			test(range, index, expected1, expected2);
 		}
 
 		@DisplayName("when range is empty")
 		@Tests({
-			"when index is before range start, fails;" +
+			"when index is before valid index range start, fails;" +
 				"[0, 0); -1;" +
-				"null",
-			"when index is at range start, fails;" +
+				"null; -1 ∉ [0, 0)",
+			"when index is at valid index range start, fails;" +
 				"[0, 0); 0;" +
-				"null",
-			"when index is at range end, fails;" +
+				"null; 0 ∉ [0, 0)",
+			"when index is after valid index range end, fails;" +
 				"[0, 0); 1;" +
-				"null",
+				"null; 1 ∉ [0, 0)",
 		})
-		void testEmpty(@IntRange IndexRange range, int index, Integer expected) {
-			test(range, index, expected);
+		void testEmpty(@IntRange IndexRange range, int index, Integer expected1,
+			@IndexRangeException Exception expected2) {
+			test(range, index, expected1, expected2);
 		}
 
-		private void test(IndexRange range, int index, Integer expected1) {
+		private void test(IndexRange range, int index, Integer expected1,
+			Exception expected2) {
+
 			try {
-				final var returned = range.get(index);
-				assertEquals(expected1, returned,
+				final var value = range.get(index);
+				assertEquals(expected1, value,
 					format("%s.get(%d)", range, index));
-			} catch (IndexNotInRangeException exception) {
-				if (expected1 == null) {
-					final var expected2 = new IndexNotInRangeException(index, range);
+			} catch (Exception exception) {
+				if (expected2 == null) {
+					throw exception;
+				} else {
 					assertEquals(expected2, exception,
 						format("%s.get(%d)", range, index));
-				} else {
-					throw exception;
 				}
 			}
 		}
@@ -310,56 +315,57 @@ class IndexRangeTests {
 	class GetPrefixTests {
 		@DisplayName("when range is not empty")
 		@Tests({
-			"when index is before range start, fails;" +
-				"[2, 9); 1;" +
-				"null",
-			"when index is at range start, returns empty range;" +
-				"[2, 9); 2;" +
-				"[0, 0)",
-			"when index is within range, returns prefix;" +
+			"when index is before valid index range start, fails;" +
+				"[2, 9); -1;" +
+				"null; -1 ∉ [0, 7)",
+			"when index is at valid index range start, returns empty range;" +
+				"[2, 9); 0;" +
+				"[0, 0); null",
+			"when index is within valid index range, returns prefix;" +
 				"[2, 9); 4;" +
-				"[2, 4)",
-			"when index is at range end, fails;" +
-				"[2, 9); 9;" +
-				"null",
-			"when index is after range end, fails;" +
+				"[2, 6); null",
+			"when index is at valid index range end, fails;" +
+				"[2, 9); 7;" +
+				"null; 7 ∉ [0, 7)",
+			"when index is after valid index range end, fails;" +
 				"[2, 9); 12;" +
-				"null",
+				"null; 12 ∉ [0, 7)",
 		})
 		void testNotEmpty(@IntRange IndexRange range, int index,
-			@IntRange IndexRange expected) {
-			test(range, index, expected);
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+			test(range, index, expected1, expected2);
 		}
 
 		@DisplayName("when range is empty")
 		@Tests({
-			"when index is before range, fails;" +
+			"when index is before valid index range start, fails;" +
 				"[0, 0); -5;" +
-				"null",
-			"when index is 0, fails;" +
+				"null; -5 ∉ [0, 0)",
+			"when index is at valid index range start, fails;" +
 				"[0, 0); 0;" +
-				"null",
-			"when index is after range end, fails;" +
-				"[0, 0); 5;" +
-				"null",
+				"null; 0 ∉ [0, 0)",
+			"when index is after valid index range end, fails;" +
+				"[0, 0); 1;" +
+				"null; 1 ∉ [0, 0)",
 		})
 		void testEmpty(@IntRange IndexRange range, int index,
-			@IntRange IndexRange expected) {
-			test(range, index, expected);
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+			test(range, index, expected1, expected2);
 		}
 
-		private void test(IndexRange range, int index, IndexRange expected1) {
+		private void test(IndexRange range, int index, IndexRange expected1,
+			Exception expected2) {
+
 			try {
 				final var prefix = range.getPrefix(index);
 				assertEquals(expected1, prefix,
-					format("%s.getPrefix(%d)", range, index));
-			} catch (IndexNotInRangeException exception) {
-				if (expected1 == null) {
-					final var expected2 = new IndexNotInRangeException(index, range);
-					assertEquals(expected2, exception,
-						format("%s.getPrefix(%d)", range, index));
-				} else {
+					format("%s.get(%d)", range, index));
+			} catch (Exception exception) {
+				if (expected2 == null) {
 					throw exception;
+				} else {
+					assertEquals(expected2, exception,
+						format("%s.get(%d)", range, index));
 				}
 			}
 		}
@@ -370,56 +376,57 @@ class IndexRangeTests {
 	class GetSuffixTests {
 		@DisplayName("when range is not empty")
 		@Tests({
-			"when index is before range, fails;" +
-				"[2, 9); 1;" +
-				"null",
-			"when index is at range start, returns range;" +
-				"[2, 9); 2;" +
-				"[2, 9)",
-			"when index is within range, returns suffix;" +
+			"when index is before valid index range start, fails;" +
+				"[2, 9); -1;" +
+				"null; -1 ∉ [0, 7)",
+			"when index is at valid index range start, returns range;" +
+				"[2, 9); 0;" +
+				"[2, 9); null",
+			"when index is within valid index range, returns suffix;" +
 				"[2, 9); 4;" +
-				"[4, 9)",
-			"when index is at range end, fails;" +
-				"[2, 9); 9;" +
-				"null",
-			"when index is after range end, fails;" +
+				"[6, 9); null",
+			"when index is at valid index range end, fails;" +
+				"[2, 9); 7;" +
+				"null; 7 ∉ [0, 7)",
+			"when index is after valid index range end, fails;" +
 				"[2, 9); 12;" +
-				"null",
+				"null; 12 ∉ [0, 7)",
 		})
 		void testNotEmpty(@IntRange IndexRange range, int index,
-			@IntRange IndexRange expected) {
-			test(range, index, expected);
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+			test(range, index, expected1, expected2);
 		}
 
 		@DisplayName("when range is empty")
 		@Tests({
-			"when index is before range, fails;" +
+			"when index is before valid index range start, fails;" +
 				"[0, 0); -5;" +
-				"null",
-			"when index is 0, fails;" +
+				"null; -5 ∉ [0, 0)",
+			"when index is at valid index range start, fails;" +
 				"[0, 0); 0;" +
-				"null",
-			"when index is after range end, fails;" +
-				"[0, 0); 5;" +
-				"null",
+				"null; 0 ∉ [0, 0)",
+			"when index is after valid index range end, fails;" +
+				"[0, 0); 1;" +
+				"null; 1 ∉ [0, 0)",
 		})
 		void testEmpty(@IntRange IndexRange range, int index,
-			@IntRange IndexRange expected) {
-			test(range, index, expected);
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+			test(range, index, expected1, expected2);
 		}
 
-		private void test(IndexRange range, int index, IndexRange expected1) {
+		private void test(IndexRange range, int index, IndexRange expected1,
+			Exception expected2) {
+
 			try {
-				final var prefix = range.getSuffix(index);
-				assertEquals(expected1, prefix,
-					format("%s.getSuffix(%d)", range, index));
-			} catch (IndexNotInRangeException exception) {
-				if (expected1 == null) {
-					final var expected2 = new IndexNotInRangeException(index, range);
-					assertEquals(expected2, exception,
-						format("%s.getSuffix(%d)", range, index));
-				} else {
+				final var suffix = range.getSuffix(index);
+				assertEquals(expected1, suffix,
+					format("%s.get(%d)", range, index));
+			} catch (Exception exception) {
+				if (expected2 == null) {
 					throw exception;
+				} else {
+					assertEquals(expected2, exception,
+						format("%s.get(%d)", range, index));
 				}
 			}
 		}
@@ -430,55 +437,52 @@ class IndexRangeTests {
 	class TestGetIndexRange {
 		@DisplayName("when range is not empty")
 		@Tests({
-			"when argument range is before range, fails;" +
-				"[6, 9); [1, 4);" +
-				"null",
-			"when argument range starts before range, fails;" +
-				"[6, 9); [4, 7);" +
-				"null",
-			"when argument range starts at range start, returns argument range;" +
-				"[6, 9); [6, 8);" +
-				"[6, 8)",
-			"when argument range equals range, returns argument range;" +
+			"when argument range starts at valid index range start and ends within valid index range, returns range;" +
+				"[6, 9); [0, 2);" +
+				"[6, 8); null",
+			"when argument range coincides with valid index range, returns range;" +
+				"[6, 9); [0, 3);" +
+				"[6, 9); null",
+			"when argument range starts within valid index range and ends after valid index range end, fails;" +
+				"[6, 9); [0, 7);" +
+				"null; [0, 7) ⊈ [0, 3)",
+			"when argument range starts and ends after valid index range end, fails;" +
 				"[6, 9); [6, 9);" +
-				"[6, 9)",
-			"when argument range ends after range, fails;" +
-				"[6, 9); [7, 11);" +
-				"null",
-			"when argument range is after range, fails;" +
-				"[6, 9); [12, 17);" +
-				"null",
+				"null; [6, 9) ⊈ [0, 3)",
 			"when argument range is empty, return empty range;" +
 				"[6, 9); [0, 0);" +
-				"[0, 0)"
+				"[0, 0); null"
 		})
 		void testNotEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
-			@IntRange IndexRange expected) {
-			test(range1, range2, expected);
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+			test(range1, range2, expected1, expected2);
 		}
 
 		@DisplayName("when range is empty")
 		@Tests({
 			"when argument range is not empty, fails;" +
 				"[0, 0); [6, 9);" +
-				"null",
+				"null; [6, 9) ⊈ [0, 0)",
 			"when argument range is empty, returns empty range;" +
 				"[0, 0); [0, 0);" +
-				"[0, 0)"
+				"[0, 0); null"
 		})
 		void testEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
-			@IntRange IndexRange expected) {
-			test(range1, range2, expected);
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
+			test(range1, range2, expected1, expected2);
 		}
 
-		private void test(IndexRange range1, IndexRange range2, IndexRange expected1) {
+		private void test(IndexRange range1, IndexRange range2,
+			IndexRange expected1, Exception expected2) {
+
 			try {
 				final var subrange = range1.get(range2);
 				assertEquals(expected1, subrange,
 					format("%s.get(%s)", range1, range2));
 			} catch (IndexRangeNotInRangeException exception) {
-				if (expected1 == null) {
-					final var expected2 = new IndexRangeNotInRangeException(range2, range1);
+				if (expected2 == null) {
+					throw exception;
+				} else {
 					assertEquals(expected2, exception,
 						format("%s.get(%s)", range1, range2));
 				}
@@ -495,12 +499,12 @@ class IndexRangeTests {
 			"when index is before range start, returns empty optional;" +
 				"[2, 9); 0;" +
 				"null",
-			"when index is at range start, returns index;" +
+			"when index is at range start, returns its index;" +
 				"[6, 8); 6;" +
-				"6",
-			"when index is within range, returns index;" +
+				"0",
+			"when index is within range, returns its index;" +
 				"[4, 9); 6;" +
-				"6",
+				"2",
 			"when index is at range end, returns empty optional;" +
 				"[3, 8); 8;" +
 				"null",
@@ -528,12 +532,12 @@ class IndexRangeTests {
 			"when index is before range start, returns empty sequence;" +
 				"[4, 9); 2;" +
 				"[]",
-			"when index is at range start, returns index sequence;" +
+			"when index is at range start, returns its index;" +
 				"[4, 9); 4;" +
-				"[4]",
-			"when index is withing range, returns index sequence;" +
+				"[0]",
+			"when index is withing range, returns its index;" +
 				"[4, 9); 7;" +
-				"[7]",
+				"[3]",
 			"when index is at range end, returns empty sequence;" +
 				"[4, 9); 9;" +
 				"[]",
@@ -581,7 +585,7 @@ class IndexRangeTests {
 	class FindSequenceTests {
 		@DisplayName("when range is not empty")
 		@Tests({
-			"when sequence is present, returns it index;" +
+			"when sequence is present, returns its index;" +
 				"[3, 9); [5, 6, 7];" +
 				"[2]",
 			"when sequence is absent, returns empty sequence;" +
@@ -670,7 +674,7 @@ class IndexRangeTests {
 			"when argument range end differs, returns false;" +
 				"[4, 8); [3, 8);" +
 				"false",
-			"when argument range in null, returns false;" +
+			"when argument range is null, returns false;" +
 				"[4, 8); null;" +
 				"false"
 		})
@@ -703,6 +707,100 @@ class IndexRangeTests {
 		}
 	}
 
+	@DisplayName(".iterator(int)")
+	@Nested
+	class IteratorIntTests {
+		@DisplayName("when range is not empty")
+		@Tests({
+			"when index is before valid index range start, fails;" +
+				"[2, 6); -2;" +
+				"null; -2 ∉ [0, 4)",
+			"when index is at valid index range start, returns all items iterator;" +
+				"[2, 6); 0;" +
+				"[2, 3, 4, 5]; null",
+			"when index is within valid index range, returns suffix iterator;" +
+				"[2, 6); 2;" +
+				"[4, 5]; null",
+			"when index is at valid index range end, fails;" +
+				"[2, 6); 6;" +
+				"null; 6 ∉ [0, 4)",
+			"when index is after valid index range end, fails;" +
+				"[2, 6); 9;" +
+				"null; 9 ∉ [0, 4)"
+		})
+		void testNotEmpty(@IntRange IndexRange range, int index,
+			@StringList List<String> expected1,
+			@IndexRangeException Exception expected2) {
+			test(range, index, expected1, expected2);
+		}
+
+		@DisplayName("when range is empty")
+		@Tests({
+			"when index is before valid index range start, fails;" +
+				"[0, 0); -1;" +
+				"null; -1 ∉ [0, 0)",
+			"when index is at valid index range start, fails;" +
+				"[0, 0); 0;" +
+				"null; 0 ∉ [0, 0)",
+			"when index is after valid index range end, fails;" +
+				"[0, 0); 1;" +
+				"null; 1 ∉ [0, 0)"
+		})
+		void testEmpty(@IntRange IndexRange range, int index,
+			@StringList List<String> expected1,
+			@IndexRangeException Exception expected2) {
+			test(range, index, expected1, expected2);
+		}
+
+		void test(IndexRange range, int index, List<String> expected1,
+			Exception expected2) {
+
+			try {
+				final var iterator = range.iterator(index);
+				final var iterated = new MutableList<String>();
+				while (iterator.hasNext()) {
+					final var next = iterator.next();
+					iterated.append(Integer.toString(next));
+				}
+
+				assertEquals(expected1, iterated,
+					format("%s.iterator(%d)", range, index));
+			} catch (Exception exception) {
+				if (expected2 == null) {
+					throw exception;
+				} else {
+					assertEquals(expected2, exception,
+						format("%s.iterator(%d)", range, index));
+				}
+			}
+		}
+	}
+
+	@DisplayName(".iterator()")
+	@Nested
+	class IteratorTests {
+		@DisplayName("\uD83D\uDCC1")
+		@Tests({
+			"when range is not empty, iterates values;" +
+				"[3, 7);" +
+				"[3, 4, 5, 6]",
+			"when range is empty, does nothing;" +
+				"[0, 0);" +
+				"[]"
+		})
+		void test(@IntRange IndexRange range, @StringList List<String> expected) {
+			final var iterator = range.iterator();
+			final var iterated = new MutableList<String>();
+			while (iterator.hasNext()) {
+				final var next = iterator.next();
+				iterated.append(Integer.toString(next));
+			}
+
+			assertEquals(expected, iterated,
+				format("%s.iterator()", range));
+		}
+	}
+
 	@DisplayName(".toString()")
 	@Nested
 	class ToStringTests {
@@ -719,29 +817,6 @@ class IndexRangeTests {
 			final var string = range.toString();
 			assertEquals(expected, string,
 				format("%s.toString()", range));
-		}
-	}
-
-	@DisplayName(".iterator()")
-	@Nested
-	class IteratorTests {
-		@DisplayName("\uD83D\uDE98")
-		@Tests({
-			"when range is not empty, returns index iterator;" +
-				"[2, 6);" +
-				"[2, 3, 4, 5]",
-			"when range is empty, returns empty iterator;" +
-				"[0, 0);" +
-				"[]"
-		})
-		void test(@IntRange IndexRange range, @StringList List<String> expected) {
-			final var iterated = new MutableList<String>();
-			for (var next : range) {
-				iterated.append(Integer.toString(next));
-			}
-
-			assertEquals(expected, iterated,
-				format("%s.iterator()", range));
 		}
 	}
 }
@@ -785,6 +860,75 @@ class IndexRangeTests {
 			final var converter = new IntRange.Converter();
 			return Optional.ofNullable(s)
 				.map(converter::convert);
+		}
+	}
+}
+
+@ConvertWith(IndexRangeException.Converter.class)
+@Retention(RetentionPolicy.RUNTIME)
+@interface IndexRangeException {
+	class Converter extends TypedArgumentConverter<String, Exception> {
+		protected Converter() {
+			super(String.class, Exception.class);
+		}
+
+		@Override
+		protected Exception convert(String s) throws ArgumentConversionException {
+			if (s == null) {
+				return null;
+			}
+
+			final var matcher1 = indexRegex.matcher(s);
+			if (matcher1.find()) {
+				return matchIndexNotInRangeException(matcher1);
+			}
+
+			final var matcher2 = indexRangeRegex.matcher(s);
+			if (matcher2.find()) {
+				return matchIndexRangeNotInRangeException(matcher2);
+			}
+
+			throw new ArgumentConversionException(
+				format("Cannot parse %s or %s from %s.",
+					IndexNotInRangeException.class.getName(),
+					IndexRangeNotInRangeException.class.getName(), s));
+		}
+
+		private static final Pattern indexRegex = Pattern
+			.compile("(-?\\d+)" +
+				"\\s*∉\\s*" +
+				"\\[\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*\\)");
+
+		private IndexNotInRangeException matchIndexNotInRangeException(Matcher matcher) {
+			final var index = matcher.group(1);
+			final var start = matcher.group(2);
+			final var end = matcher.group(3);
+
+			return new IndexNotInRangeException(
+				Integer.parseInt(index),
+				new IndexRange(
+					Integer.parseInt(start),
+					Integer.parseInt(end)));
+		}
+
+		private static final Pattern indexRangeRegex = Pattern
+			.compile("\\[\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*\\)" +
+				"\\s*⊈\\s*" +
+				"\\[\\s*(-?\\d+)\\s*,\\s*(-?\\d+)\\s*\\)");
+
+		private IndexRangeNotInRangeException matchIndexRangeNotInRangeException(Matcher matcher) {
+			final var start1 = matcher.group(1);
+			final var end1 = matcher.group(2);
+			final var start2 = matcher.group(3);
+			final var end2 = matcher.group(4);
+
+			return new IndexRangeNotInRangeException(
+				new IndexRange(
+					Integer.parseInt(start1),
+					Integer.parseInt(end1)),
+				new IndexRange(
+					Integer.parseInt(start2),
+					Integer.parseInt(end2)));
 		}
 	}
 }

--- a/src/test/java/com/tsyba/core/collections/ListTests.java
+++ b/src/test/java/com/tsyba/core/collections/ListTests.java
@@ -298,7 +298,7 @@ public class ListTests {
 				"[f, y, R, e, l, k, g, S]; [0, 0);" +
 				"[]"
 		})
-		void testNotEmpty(@StringList List<String> items, @IntRange IndexRange range,
+		void testNotEmpty(@StringList List<String> items, @TestRange IndexRange range,
 			@StringList List<String> expected) {
 			test(items, range, expected);
 		}
@@ -312,7 +312,7 @@ public class ListTests {
 				"[]; [0, 0);" +
 				"[]"
 		})
-		void testEmpty(@StringList List<String> items, @IntRange IndexRange range,
+		void testEmpty(@StringList List<String> items, @TestRange IndexRange range,
 			@StringList List<String> expected) {
 			test(items, range, expected);
 		}

--- a/src/test/java/com/tsyba/core/collections/SequenceTests.java
+++ b/src/test/java/com/tsyba/core/collections/SequenceTests.java
@@ -31,7 +31,7 @@ public class SequenceTests {
 				"[0, 0)"
 		})
 		void test(@StringSequence Sequence<String> items,
-			@IntRange IndexRange expected) {
+			@TestRange IndexRange expected) {
 
 			final var range = items.getIndexRange();
 			assertEquals(expected, range,
@@ -196,8 +196,8 @@ public class SequenceTests {
 				"null"
 		})
 		void testNotEmpty(@StringSequence Sequence<String> items,
-			@IntRange IndexRange range,
-			@IntRangeOptional Optional<IndexRange> expected) {
+			@TestRange IndexRange range,
+			@TestRangeOptional Optional<IndexRange> expected) {
 			test(items, range, expected);
 		}
 
@@ -208,8 +208,8 @@ public class SequenceTests {
 				"null"
 		})
 		void testEmpty(@StringSequence Sequence<String> items,
-			@IntRange IndexRange range,
-			@IntRangeOptional Optional<IndexRange> expected) {
+			@TestRange IndexRange range,
+			@TestRangeOptional Optional<IndexRange> expected) {
 			test(items, range, expected);
 		}
 

--- a/src/test/java/com/tsyba/core/collections/SequenceTests.java
+++ b/src/test/java/com/tsyba/core/collections/SequenceTests.java
@@ -30,7 +30,7 @@ public class SequenceTests {
 				"[];" +
 				"[0, 0)"
 		})
-		void test(@StringSequence Sequence<String> items,
+		void test(@TestSequence Sequence<String> items,
 			@TestRange IndexRange expected) {
 
 			final var range = items.getIndexRange();
@@ -52,7 +52,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@StringSequence Sequence<String> items,
+		void test(@TestSequence Sequence<String> items,
 			@StringOptional Optional<String> expected) {
 
 			final var item = items.getFirst();
@@ -74,7 +74,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@StringSequence Sequence<String> items,
+		void test(@TestSequence Sequence<String> items,
 			@StringOptional Optional<String> expected) {
 
 			final var item = items.getLast();
@@ -98,7 +98,7 @@ public class SequenceTests {
 				"[g, B, s, E, q, s, K]; 12;" +
 				"null; 12 ∉ [0, 7)"
 		})
-		void testNotEmpty(@StringSequence Sequence<String> items, int index,
+		void testNotEmpty(@TestSequence Sequence<String> items, int index,
 			String expected1, @IndexRangeException Exception expected2) {
 			test(items, index, expected1, expected2);
 		}
@@ -112,7 +112,7 @@ public class SequenceTests {
 				"[]; 0;" +
 				"null; 0 ∉ [0, 0)"
 		})
-		void testEmpty(@StringSequence Sequence<String> items, int index,
+		void testEmpty(@TestSequence Sequence<String> items, int index,
 			String expected1, @IndexRangeException Exception expected2) {
 			test(items, index, expected1, expected2);
 		}
@@ -151,7 +151,7 @@ public class SequenceTests {
 				"[g, T, s, l, I, o]; 13;" +
 				"null",
 		})
-		void testNotEmpty(@StringSequence Sequence<String> items, int index,
+		void testNotEmpty(@TestSequence Sequence<String> items, int index,
 			@IntOptional Optional<Integer> expected) {
 			test(items, index, expected);
 		}
@@ -165,7 +165,7 @@ public class SequenceTests {
 				"[]; 0;" +
 				"null",
 		})
-		void testEmpty(@StringSequence Sequence<String> items, int index,
+		void testEmpty(@TestSequence Sequence<String> items, int index,
 			@IntOptional Optional<Integer> expected) {
 			test(items, index, expected);
 		}
@@ -195,7 +195,7 @@ public class SequenceTests {
 				"[g, I, m, k, L, s, D, n]; [3, 15);" +
 				"null"
 		})
-		void testNotEmpty(@StringSequence Sequence<String> items,
+		void testNotEmpty(@TestSequence Sequence<String> items,
 			@TestRange IndexRange range,
 			@TestRangeOptional Optional<IndexRange> expected) {
 			test(items, range, expected);
@@ -207,7 +207,7 @@ public class SequenceTests {
 				"[]; [0, 2);" +
 				"null"
 		})
-		void testEmpty(@StringSequence Sequence<String> items,
+		void testEmpty(@TestSequence Sequence<String> items,
 			@TestRange IndexRange range,
 			@TestRangeOptional Optional<IndexRange> expected) {
 			test(items, range, expected);
@@ -241,7 +241,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@StringSequence Sequence<String> items,
+		void test(@TestSequence Sequence<String> items,
 			@StringOptional Optional<String> expected) {
 
 			final var matched = items.matchFirst((item) -> {
@@ -273,7 +273,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@StringSequence Sequence<String> items, String item,
+		void test(@TestSequence Sequence<String> items, String item,
 			@IntOptional Optional<Integer> expected) {
 
 			final var index = items.findFirst(item);
@@ -301,7 +301,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@StringSequence Sequence<String> items,
+		void test(@TestSequence Sequence<String> items,
 			@IntOptional Optional<Integer> expected) {
 
 			final var index = items.findFirst((item) ->
@@ -335,8 +335,8 @@ public class SequenceTests {
 				"[u, Y, k, L, m, n, F, s, d]; [];" +
 				"0"
 		})
-		void testNotEmpty(@StringSequence Sequence<String> items1,
-			@StringSequence Sequence<String> items2,
+		void testNotEmpty(@TestSequence Sequence<String> items1,
+			@TestSequence Sequence<String> items2,
 			@IntOptional Optional<Integer> expected) {
 			test(items1, items2, expected);
 		}
@@ -350,8 +350,8 @@ public class SequenceTests {
 				"[]; [];" +
 				"null"
 		})
-		void testEmpty(@StringSequence Sequence<String> items1,
-			@StringSequence Sequence<String> items2,
+		void testEmpty(@TestSequence Sequence<String> items1,
+			@TestSequence Sequence<String> items2,
 			@IntOptional Optional<Integer> expected) {
 			test(items1, items2, expected);
 		}
@@ -377,7 +377,7 @@ public class SequenceTests {
 				"[];" +
 				"[]"
 		})
-		void test(@StringSequence Sequence<String> items,
+		void test(@TestSequence Sequence<String> items,
 			@StringMap Map<String, String> expected) {
 
 			final var enumerated = new MutableMap<Integer, String>();
@@ -395,8 +395,8 @@ public class SequenceTests {
 }
 
 @Retention(RetentionPolicy.RUNTIME)
-@ConvertWith(StringSequence.Converter.class)
-@interface StringSequence {
+@ConvertWith(TestSequence.Converter.class)
+@interface TestSequence {
 	@SuppressWarnings("rawtypes")
 	class Converter extends TypedArgumentConverter<String, Sequence> {
 		protected Converter() {
@@ -408,7 +408,72 @@ public class SequenceTests {
 			final var items = new StringArray.Converter()
 				.convert(s);
 
-			return new ArraySequence<>(items);
+			return new Sequence<>() {
+				@Override
+				public Sequence<String> getPrefix(int index) {
+					return null;
+				}
+
+				@Override
+				public Sequence<String> getSuffix(int index) {
+					return null;
+				}
+
+				@Override
+				public Sequence<String> get(IndexRange range) {
+					return null;
+				}
+
+				@Override
+				public Sequence<Integer> find(String item) {
+					return null;
+				}
+
+				@Override
+				public Sequence<Integer> find(Sequence<String> items) {
+					return null;
+				}
+
+				@Override
+				public Collection<String> getDistinct() {
+					return null;
+				}
+
+				@Override
+				public Sequence<String> reverse() {
+					return null;
+				}
+
+				@Override
+				public Sequence<String> filter(Predicate<String> condition) {
+					return null;
+				}
+
+				@Override
+				public <R> Sequence<R> convert(Function<String, R> converter) {
+					return null;
+				}
+
+				@Override
+				public Iterator<String> iterator() {
+					return new Iterator<>() {
+						private int index = 0;
+
+						@Override
+						public boolean hasNext() {
+							return index < items.length;
+						}
+
+						@Override
+						public String next() {
+							final var item = items[index];
+							++index;
+
+							return item;
+						}
+					};
+				}
+			};
 		}
 	}
 }
@@ -427,108 +492,5 @@ public class SequenceTests {
 			return Optional.ofNullable(s)
 				.map(Integer::parseInt);
 		}
-	}
-}
-
-class ArraySequence<T> implements Sequence<T> {
-	private final T[] items;
-
-	ArraySequence(T[] items) {
-		this.items = items;
-	}
-
-	@Override
-	public Sequence<T> getPrefix(int index) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Sequence<T> getSuffix(int index) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Sequence<T> get(IndexRange range) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Sequence<Integer> find(T item) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Sequence<Integer> find(Sequence<T> items) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Sequence<T> reverse() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Collection<T> getDistinct() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Sequence<T> filter(Predicate<T> condition) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public <R> Sequence<R> convert(Function<T, R> converter) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Iterator<T> iterator(int start) {
-		final var range = getIndexRange();
-		if (!range.contains(start)) {
-			throw new IndexNotInRangeException(start, range);
-		}
-
-		return new Iterator<>() {
-			private int index = start;
-
-			@Override
-			public boolean hasNext() {
-				return index < items.length;
-			}
-
-			@Override
-			public T next() {
-				final var next = items[index];
-				++index;
-
-				return next;
-			}
-		};
-	}
-
-	@Override
-	public Iterator<T> iterator() {
-		return new Iterator<>() {
-			private int index = 0;
-
-			@Override
-			public boolean hasNext() {
-				return index < items.length;
-			}
-
-			@Override
-			public T next() {
-				final var next = items[index];
-				++index;
-
-				return next;
-			}
-		};
-	}
-
-	@Override
-	public String toString() {
-		return "[" + join(", ") + "]";
 	}
 }


### PR DESCRIPTION
This update fixes index-based operations in IndexRange, which previously returned values from starting index instead of their actual index within a range.

Fixes #28.