### PR TITLE
Rename Collection.filter and Sequence.find.

### DIFF
--- a/src/main/java/com/tsyba/core/collections/ArrayIterator.java
+++ b/src/main/java/com/tsyba/core/collections/ArrayIterator.java
@@ -1,0 +1,31 @@
+package com.tsyba.core.collections;
+
+import java.util.Iterator;
+
+class ArrayIterator<T> implements Iterator<T> {
+	private final T[] items;
+	private int index;
+
+	ArrayIterator(T[] items, int start) {
+		this.items = items;
+		this.index = start;
+	}
+
+	ArrayIterator(T[] items) {
+		this.items = items;
+		this.index = 0;
+	}
+
+	@Override
+	public boolean hasNext() {
+		return index < items.length;
+	}
+
+	@Override
+	public T next() {
+		final var next = items[index];
+		index++;
+
+		return next;
+	}
+}

--- a/src/main/java/com/tsyba/core/collections/Collection.java
+++ b/src/main/java/com/tsyba/core/collections/Collection.java
@@ -141,7 +141,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * collection; returns {@code false} otherwise.
 	 */
 	default boolean contains(Collection<T> items) {
-		return items.eachMatches(this::contains);
+		return items.allMatch(this::contains);
 	}
 
 	/**
@@ -151,8 +151,13 @@ public interface Collection<T> extends Iterable<T> {
 	 * When this collection is empty, returns {@code true}.
 	 */
 	default boolean noneMatches(Predicate<T> condition) {
-		return matchAny(condition)
-			.isEmpty();
+		for (var item : this) {
+			if (condition.test(item)) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -162,19 +167,29 @@ public interface Collection<T> extends Iterable<T> {
 	 * When this collection is empty, returns {@code false}.
 	 */
 	default boolean anyMatches(Predicate<T> condition) {
-		return matchAny(condition)
-			.isPresent();
+		for (var item : this) {
+			if (condition.test(item)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
-	 * Returns {@code true} when each item of this collection satisfies the specified
+	 * Returns {@code true} when all items of this collection satisfy the specified
 	 * {@link Predicate}; returns {@code false} otherwise.
 	 * <p>
 	 * When this collection is empty, returns {@code true}.
 	 */
-	default boolean eachMatches(Predicate<T> condition) {
-		return matchAny((item) -> !condition.test(item))
-			.isEmpty();
+	default boolean allMatch(Predicate<T> condition) {
+		for (var item : this) {
+			if (!condition.test(item)) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -310,7 +325,7 @@ public interface Collection<T> extends Iterable<T> {
 	 * Returns items of this collection, converted by the specified {@link Function}.
 	 * <p>
 	 * When the specified {@link Function} returns {@code null}, the converted value will
-	 * be ignored. Therefore, this method can be used to both filter and convert this
+	 * be ignored. Therefore, this method can be used to both match and convert this
 	 * collection in a single operation.
 	 */
 	<R> Collection<R> convert(Function<T, R> converter);

--- a/src/main/java/com/tsyba/core/collections/Collection.java
+++ b/src/main/java/com/tsyba/core/collections/Collection.java
@@ -196,6 +196,12 @@ public interface Collection<T> extends Iterable<T> {
 	}
 
 	/**
+	 * Returns all items of this collection, which satisfy the specified
+	 * {@link Predicate}.
+	 */
+	Collection<T> matchAll(Predicate<T> condition);
+
+	/**
 	 * Returns distinct items in this collection.
 	 */
 	Collection<T> getDistinct();
@@ -285,11 +291,6 @@ public interface Collection<T> extends Iterable<T> {
 
 		return this;
 	}
-
-	/**
-	 * Returns items of this collection, which satisfy the specified {@link Predicate}.
-	 */
-	Collection<T> filter(Predicate<T> condition);
 
 	/**
 	 * Returns items of this collection, converted by the specified {@link Function}.

--- a/src/main/java/com/tsyba/core/collections/Collection.java
+++ b/src/main/java/com/tsyba/core/collections/Collection.java
@@ -46,6 +46,9 @@ public interface Collection<T> extends Iterable<T> {
 	 * {@link Comparator}.
 	 * <p>
 	 * When this collection is empty, returns an empty {@link Optional}.
+	 *
+	 * @throws UnsupportedOperationException when items of this collection are not
+	 * {@link Comparable}
 	 */
 	default Optional<T> getMin(Comparator<T> comparator) {
 		final var iterator = iterator();
@@ -53,15 +56,19 @@ public interface Collection<T> extends Iterable<T> {
 			return Optional.empty();
 		}
 
-		var minimum = iterator.next();
+		var min = iterator.next();
+		if (!(min instanceof Comparable)) {
+			throw new UnsupportedOperationException("Collection items are not comparable.");
+		}
+
 		while (iterator.hasNext()) {
 			final var item = iterator.next();
-			if (comparator.compare(minimum, item) > 0) {
-				minimum = item;
+			if (comparator.compare(min, item) > 0) {
+				min = item;
 			}
 		}
 
-		return Optional.of(minimum);
+		return Optional.of(min);
 	}
 
 	/**
@@ -82,6 +89,9 @@ public interface Collection<T> extends Iterable<T> {
 	 * {@link Comparator}.
 	 * <p>
 	 * When this collection is empty, returns an empty {@link Optional}.
+	 *
+	 * @throws UnsupportedOperationException when items of this collection are not
+	 * {@link Comparable}
 	 */
 	default Optional<T> getMax(Comparator<T> comparator) {
 		final var iterator = iterator();
@@ -89,15 +99,19 @@ public interface Collection<T> extends Iterable<T> {
 			return Optional.empty();
 		}
 
-		var maximum = iterator.next();
+		var max = iterator.next();
+		if (!(max instanceof Comparable)) {
+			throw new UnsupportedOperationException("Collection items are not comparable.");
+		}
+
 		while (iterator.hasNext()) {
 			final var item = iterator.next();
-			if (comparator.compare(maximum, item) < 0) {
-				maximum = item;
+			if (comparator.compare(max, item) < 0) {
+				max = item;
 			}
 		}
 
-		return Optional.of(maximum);
+		return Optional.of(max);
 	}
 
 	/**

--- a/src/main/java/com/tsyba/core/collections/IndexRange.java
+++ b/src/main/java/com/tsyba/core/collections/IndexRange.java
@@ -151,14 +151,14 @@ public class IndexRange implements Sequence<Integer> {
 	}
 
 	@Override
-	public Sequence<Integer> find(Integer item) {
+	public Sequence<Integer> findAll(Integer item) {
 		return contains(item)
 			? new List<>(item - start)
 			: new List<>();
 	}
 
 	@Override
-	public Sequence<Integer> find(Sequence<Integer> items) {
+	public Sequence<Integer> findAll(Sequence<Integer> items) {
 		final var indexes = new MutableList<Integer>();
 		final var range = getIndexRange();
 

--- a/src/main/java/com/tsyba/core/collections/IndexRange.java
+++ b/src/main/java/com/tsyba/core/collections/IndexRange.java
@@ -131,6 +131,19 @@ public class IndexRange implements Sequence<Integer> {
 	}
 
 	@Override
+	public Sequence<Integer> matchAll(Predicate<Integer> condition) {
+		final var store = new ContiguousArrayStore(end - start);
+		for (var index : this) {
+			if (condition.test(index)) {
+				store.append(index);
+			}
+		}
+
+		store.removeExcessCapacity();
+		return new List<>(store);
+	}
+
+	@Override
 	public Optional<Integer> findFirst(Integer item) {
 		return contains(item)
 			? Optional.of(item - start)
@@ -188,19 +201,6 @@ public class IndexRange implements Sequence<Integer> {
 	public Sequence<Integer> reverse() {
 		// todo: implement IndexRange.reverse()
 		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Sequence<Integer> filter(Predicate<Integer> condition) {
-		final var store = new ContiguousArrayStore(end - start);
-		for (var index : this) {
-			if (condition.test(index)) {
-				store.append(index);
-			}
-		}
-
-		store.removeExcessCapacity();
-		return new List<>(store);
 	}
 
 	@Override

--- a/src/main/java/com/tsyba/core/collections/List.java
+++ b/src/main/java/com/tsyba/core/collections/List.java
@@ -96,6 +96,18 @@ public class List<T> implements Sequence<T> {
 	}
 
 	@Override
+	public List<T> matchAll(Predicate<T> condition) {
+		final var filtered = new MutableList<T>();
+		for (var item : this) {
+			if (condition.test(item)) {
+				filtered.append(item);
+			}
+		}
+
+		return filtered.toImmutable();
+	}
+
+	@Override
 	public List<Integer> find(T item) {
 		final var indexes = new MutableList<Integer>();
 		enumerate((index, item2) -> {
@@ -162,18 +174,6 @@ public class List<T> implements Sequence<T> {
 	@Override
 	public List<T> enumerate(BiConsumer<Integer, T> operation) {
 		return (List<T>) Sequence.super.enumerate(operation);
-	}
-
-	@Override
-	public List<T> filter(Predicate<T> condition) {
-		final var filtered = new MutableList<T>();
-		for (var item : this) {
-			if (condition.test(item)) {
-				filtered.append(item);
-			}
-		}
-
-		return filtered.toImmutable();
 	}
 
 	@Override

--- a/src/main/java/com/tsyba/core/collections/List.java
+++ b/src/main/java/com/tsyba/core/collections/List.java
@@ -208,23 +208,9 @@ public class List<T> implements Sequence<T> {
 
 	@Override
 	public Iterator<T> iterator(int start) {
-		return new Iterator<>() {
-			private int index = start;
-
-			@Override
-			public boolean hasNext() {
-				return index < store.itemCount;
-			}
-
-			@Override
-			public T next() {
-				@SuppressWarnings("unchecked")
-				final var item = (T) store.items[index];
-				++index;
-
-				return item;
-			}
-		};
+		@SuppressWarnings("unchecked")
+		final var items = (T[]) store.items;
+		return new ArrayIterator<>(items, start);
 	}
 
 	@Override

--- a/src/main/java/com/tsyba/core/collections/List.java
+++ b/src/main/java/com/tsyba/core/collections/List.java
@@ -97,18 +97,18 @@ public class List<T> implements Sequence<T> {
 
 	@Override
 	public List<T> matchAll(Predicate<T> condition) {
-		final var filtered = new MutableList<T>();
+		final var matches = new MutableList<T>();
 		for (var item : this) {
 			if (condition.test(item)) {
-				filtered.append(item);
+				matches.append(item);
 			}
 		}
 
-		return filtered.toImmutable();
+		return matches.toImmutable();
 	}
 
 	@Override
-	public List<Integer> find(T item) {
+	public List<Integer> findAll(T item) {
 		final var indexes = new MutableList<Integer>();
 		enumerate((index, item2) -> {
 			if (item2.equals(item)) {
@@ -120,7 +120,7 @@ public class List<T> implements Sequence<T> {
 	}
 
 	@Override
-	public Sequence<Integer> find(Sequence<T> items) {
+	public Sequence<Integer> findAll(Sequence<T> items) {
 		final var indexes = new MutableList<Integer>();
 		final var range = getIndexRange();
 

--- a/src/main/java/com/tsyba/core/collections/MutableList.java
+++ b/src/main/java/com/tsyba/core/collections/MutableList.java
@@ -333,8 +333,8 @@ public class MutableList<T> extends List<T> {
 
 	@Override
 	public MutableList<T> matchAll(Predicate<T> condition) {
-		final var filtered = super.matchAll(condition);
-		return new MutableList<>(filtered.store);
+		final var matches = super.matchAll(condition);
+		return new MutableList<>(matches.store);
 	}
 
 	@Override

--- a/src/main/java/com/tsyba/core/collections/MutableList.java
+++ b/src/main/java/com/tsyba/core/collections/MutableList.java
@@ -332,6 +332,12 @@ public class MutableList<T> extends List<T> {
 	}
 
 	@Override
+	public MutableList<T> matchAll(Predicate<T> condition) {
+		final var filtered = super.matchAll(condition);
+		return new MutableList<>(filtered.store);
+	}
+
+	@Override
 	public MutableList<T> getDistinct() {
 		final var distinct = super.getDistinct();
 		return new MutableList<>(distinct);
@@ -371,18 +377,6 @@ public class MutableList<T> extends List<T> {
 	public MutableList<T> iterate(Consumer<T> operation) {
 		super.iterate(operation);
 		return this;
-	}
-
-//	@Override
-//	public MutableList<T> enumerate(BiConsumer<T, Integer> operation) {
-//		super.enumerate(operation);
-//		return this;
-//	}
-
-	@Override
-	public MutableList<T> filter(Predicate<T> condition) {
-		final var filtered = super.filter(condition);
-		return new MutableList<>(filtered.store);
 	}
 
 	@Override

--- a/src/main/java/com/tsyba/core/collections/MutableSet.java
+++ b/src/main/java/com/tsyba/core/collections/MutableSet.java
@@ -175,14 +175,14 @@ public class MutableSet<T> extends Set<T> {
 	}
 
 	@Override
-	public MutableSet<T> iterate(Consumer<T> operation) {
-		return (MutableSet<T>) super.iterate(operation);
+	public MutableSet<T> matchAll(Predicate<T> condition) {
+		final var items = super.matchAll(condition);
+		return new MutableSet<>(items.store);
 	}
 
 	@Override
-	public MutableSet<T> filter(Predicate<T> condition) {
-		final var items = super.filter(condition);
-		return new MutableSet<>(items.store);
+	public MutableSet<T> iterate(Consumer<T> operation) {
+		return (MutableSet<T>) super.iterate(operation);
 	}
 
 	@Override

--- a/src/main/java/com/tsyba/core/collections/Sequence.java
+++ b/src/main/java/com/tsyba/core/collections/Sequence.java
@@ -138,6 +138,9 @@ public interface Sequence<T> extends Collection<T> {
 		return Optional.empty();
 	}
 
+	@Override
+	Sequence<T> matchAll(Predicate<T> condition);
+
 	/**
 	 * Returns index of the first occurrence of the specified item in this sequence. When
 	 * this item does not occur in this sequence, returns an empty {@link Optional}.
@@ -238,9 +241,6 @@ public interface Sequence<T> extends Collection<T> {
 
 		return this;
 	}
-
-	@Override
-	Sequence<T> filter(Predicate<T> condition);
 
 	@Override
 	<R> Sequence<R> convert(Function<T, R> converter);

--- a/src/main/java/com/tsyba/core/collections/Sequence.java
+++ b/src/main/java/com/tsyba/core/collections/Sequence.java
@@ -212,7 +212,7 @@ public interface Sequence<T> extends Collection<T> {
 	 * When the specified item does not occur in this sequence, or this sequence is empty,
 	 * returns an empty sequence.
 	 */
-	Sequence<Integer> find(T item);
+	Sequence<Integer> findAll(T item);
 
 	/**
 	 * Returns indexes of all occurrences of the specified sequence in this sequence.
@@ -221,7 +221,7 @@ public interface Sequence<T> extends Collection<T> {
 	 * empty, returns an empty sequence. When the specified sequence is empty, returns all
 	 * indexes of this sequence.
 	 */
-	Sequence<Integer> find(Sequence<T> items);
+	Sequence<Integer> findAll(Sequence<T> items);
 
 	/**
 	 * Returns items of this sequence in reverse order.

--- a/src/main/java/com/tsyba/core/collections/Set.java
+++ b/src/main/java/com/tsyba/core/collections/Set.java
@@ -215,12 +215,7 @@ public class Set<T> implements Collection<T> {
 	}
 
 	@Override
-	public Set<T> iterate(Consumer<T> operation) {
-		return (Set<T>) Collection.super.iterate(operation);
-	}
-
-	@Override
-	public Set<T> filter(Predicate<T> condition) {
+	public Set<T> matchAll(Predicate<T> condition) {
 		final var itemCount = getCount();
 		final var store = new RobinHoodHashStore<T>(itemCount);
 
@@ -232,6 +227,11 @@ public class Set<T> implements Collection<T> {
 
 		store.removeExcessCapacity();
 		return new Set<>(store);
+	}
+
+	@Override
+	public Set<T> iterate(Consumer<T> operation) {
+		return (Set<T>) Collection.super.iterate(operation);
 	}
 
 	@Override

--- a/src/test/java/com/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/com/tsyba/core/collections/CollectionTests.java
@@ -1,5 +1,7 @@
 package com.tsyba.core.collections;
 
+import com.tsyba.core.collections.converter.StringArray;
+import com.tsyba.core.collections.converter.StringOptional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -106,7 +108,7 @@ public class CollectionTests {
 		void testNotComparable() {
 			assertThrows(UnsupportedOperationException.class,
 				() -> {
-					new PredicateCollection<>()
+					new NonComparableCollection()
 						.getMin();
 				});
 		}
@@ -162,7 +164,7 @@ public class CollectionTests {
 		void testNotComparable() {
 			assertThrows(UnsupportedOperationException.class,
 				() -> {
-					new PredicateCollection<>()
+					new NonComparableCollection()
 						.getMax();
 				});
 		}
@@ -429,11 +431,8 @@ public class CollectionTests {
 		@Test
 		void testSortNotComparable() {
 			Assertions.assertThrows(RuntimeException.class, () -> {
-				final var collection = new PredicateCollection<>(
-					String::isEmpty,
-					String::isBlank);
-
-				collection.sort();
+				new NonComparableCollection()
+					.sort();
 			}, "<non comparable items>.sort()");
 		}
 	}
@@ -441,68 +440,36 @@ public class CollectionTests {
 	@DisplayName(".shuffle(Random)")
 	@Nested
 	class ShuffleRandomTests {
-		@Test
-		@DisplayName("when collection is not empty, returns shuffled list")
-		void testNotEmpty() {
-			Collection<String> items = new ArrayCollection<>(
-				"r", "E", "V", "s", "x", "w", "O", "8");
-
-			final var time = System.currentTimeMillis();
-			final var random = new Random(time);
-
-			// shuffle items 10 times and ensure item order is different after
-			// each shuffle
-			for (var index = 0; index < 10; ++index) {
-				final Collection<String> shuffled = items.shuffle(random);
-				assertShuffled(shuffled, items,
-					format("%s.shuffle(Random)", items));
-
-				items = shuffled;
-			}
-		}
-
-		@DisplayName("when collection is empty, returns empty list")
-		@Test
-		void testEmpty() {
-			final var items = new ArrayCollection<>();
+		@DisplayName("\uD83D\uDC90")
+		@Tests({
+			"when collection is not empty, returns items shuffled;" +
+				"[r, E, V, s, x, w,O, 8]",
+			"when collection is empty, returns empty collection;" +
+				"[]"
+		})
+		void test(@StringCollection Collection<String> items) {
 			final var time = System.currentTimeMillis();
 			final var random = new Random(time);
 
 			final var shuffled = items.shuffle(random);
-			final var items2 = new List<>(items);
-
-			assertEquals(items2, shuffled,
-				format("%s.shuffle(Random)", items));
+			assertShuffled(shuffled, items,
+				format("%s.shuffle()", items));
 		}
 	}
 
 	@DisplayName(".shuffle()")
 	@Nested
 	class ShuffleTests {
-		@Test
-		@DisplayName("when collection is not empty, returns shuffled list")
-		void testNotEmpty() {
-			Collection<String> items = new ArrayCollection<>(
-				"o", "M", "F", "0", "K", "z", "v", "S");
-
-			for (var index = 0; index < 10; ++index) {
-				final var shuffled = items.shuffle();
-				assertShuffled(shuffled, items,
-					format("%s.shuffle()", items));
-
-				items = shuffled;
-			}
-		}
-
-		@DisplayName("when collection is empty, returns empty list")
-		@Test
-		void testEmpty() {
-			final var items = new ArrayCollection<>();
-
+		@DisplayName("\uD83C\uDF16")
+		@Tests({
+			"when collection is not empty, returns items shuffled;" +
+				"[o, M, F, 0, K, z, v, S]",
+			"when collection is empty, returns empty collection;" +
+				"[]"
+		})
+		void test(@StringCollection Collection<String> items) {
 			final var shuffled = items.shuffle();
-			final var items2 = new List<>(items);
-
-			assertEquals(items2, shuffled,
+			assertShuffled(shuffled, items,
 				format("%s.shuffle()", items));
 		}
 	}
@@ -512,11 +479,15 @@ public class CollectionTests {
 
 		final var items1 = shuffled.toArray(String[].class);
 		final var items2 = unshuffled.toArray(String[].class);
-		assertFalse(Arrays.equals(items1, items2), message);
+		if (items1.length == 0) {
+			assertEquals(0, items2.length);
+		} else {
+			assertFalse(Arrays.equals(items1, items2), message);
 
-		Arrays.sort(items1);
-		Arrays.sort(items2);
-		assertArrayEquals(items1, items2, message);
+			Arrays.sort(items1);
+			Arrays.sort(items2);
+			assertArrayEquals(items1, items2, message);
+		}
 	}
 
 	@DisplayName(".iterate(Consumer<T>)")
@@ -649,134 +620,59 @@ public class CollectionTests {
 			final var items = new StringArray.Converter()
 				.convert(s);
 
-			return new ArrayCollection<>(items) {
+			return new Collection<>() {
+				@Override
+				public Collection<String> getDistinct() {
+					throw new UnsupportedOperationException();
+				}
+
+				@Override
+				public Collection<String> matchAll(Predicate<String> condition) {
+					throw new UnsupportedOperationException();
+				}
+
+				@Override
+				public <R> Collection<R> convert(Function<String, R> converter) {
+					throw new UnsupportedOperationException();
+				}
+
+				@Override
+				public Iterator<String> iterator() {
+					return new ArrayIterator<>(items);
+				}
 			};
 		}
 	}
 }
 
-@Retention(RetentionPolicy.RUNTIME)
-@ConvertWith(StringArray.Converter.class)
-@interface StringArray {
-	class Converter extends TypedArgumentConverter<String, String[]> {
-		protected Converter() {
-			super(String.class, String[].class);
-		}
+class NonComparableCollection implements Collection<Predicate<?>> {
+	private final Predicate<?>[] items;
 
-		@Override
-		protected String[] convert(String s) throws ArgumentConversionException {
-			if (s == null) {
-				return null;
-			}
-
-			final var substring = s.substring(
-				s.indexOf("[") + 1,
-				s.lastIndexOf("]"));
-
-			if (substring.isBlank()) {
-				return new String[0];
-			} else {
-				final var string = substring.split("\\s*,\\s*");
-
-				return Arrays.stream(string)
-					.filter((item) -> !item.equals("null"))
-					.toArray(String[]::new);
-			}
-		}
-	}
-}
-
-@ConvertWith(StringOptional.Converter.class)
-@Retention(RetentionPolicy.RUNTIME)
-@interface StringOptional {
-	@SuppressWarnings("rawtypes")
-	class Converter extends TypedArgumentConverter<String, Optional> {
-		protected Converter() {
-			super(String.class, Optional.class);
-		}
-
-		@Override
-		protected Optional<String> convert(String s) throws ArgumentConversionException {
-			return Optional.ofNullable(s);
-		}
-	}
-}
-
-class ArrayCollection<T> implements Collection<T> {
-	final Object[] items;
-
-	@SafeVarargs
-	protected ArrayCollection(T... items) {
-		this.items = items;
-	}
-
-	@Override
-	public Collection<T> getDistinct() {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Collection<T> matchAll(Predicate<T> condition) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public <R> Collection<R> convert(Function<T, R> converter) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Iterator<T> iterator() {
-		return new Iterator<>() {
-			private int index = 0;
-
-			@Override
-			public boolean hasNext() {
-				return index < items.length;
-			}
-
-			@Override
-			public T next() {
-				@SuppressWarnings("unchecked")
-				var item = (T) items[index];
-				++index;
-				return item;
-			}
+	public NonComparableCollection() {
+		this.items = new Predicate[]{
+			(item) -> ((String) item).isBlank(),
+			(item) -> ((String) item).isEmpty()
 		};
 	}
 
 	@Override
-	public String toString() {
-		return "[" + join(", ") + "]";
-	}
-}
-
-class PredicateCollection<T> implements Collection<Predicate<T>> {
-	final Predicate<T>[] items;
-
-	@SafeVarargs
-	public PredicateCollection(Predicate<T>... items) {
-		this.items = items;
-	}
-
-	@Override
-	public Collection<Predicate<T>> getDistinct() {
+	public Collection<Predicate<?>> matchAll(Predicate<Predicate<?>> condition) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public Collection<Predicate<T>> matchAll(Predicate<Predicate<T>> condition) {
+	public Collection<Predicate<?>> getDistinct() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public <R> Collection<R> convert(Function<Predicate<T>, R> converter) {
+	public <R> Collection<R> convert(Function<Predicate<?>, R> converter) {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public Iterator<Predicate<T>> iterator() {
-		throw new UnsupportedOperationException();
+	public Iterator<Predicate<?>> iterator() {
+		return new ArrayIterator<>(this.items);
 	}
 }
 

--- a/src/test/java/com/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/com/tsyba/core/collections/CollectionTests.java
@@ -299,7 +299,7 @@ public class CollectionTests {
 		}
 	}
 
-	@DisplayName(".eachMatches(Predicate<T>)")
+	@DisplayName(".allMatch(Predicate<T>)")
 	@Nested
 	class EachMatchesTests {
 		@DisplayName("\uD83D\uDD2A")
@@ -318,13 +318,13 @@ public class CollectionTests {
 				"true",
 		})
 		void test(@StringCollection Collection<String> items, boolean expected) {
-			final var matches = items.eachMatches((item) -> {
+			final var matches = items.allMatch((item) -> {
 				return item.toLowerCase()
 					.equals(item);
 			});
 
 			assertEquals(expected, matches,
-				format("%s.eachMatches(Predicate<T>)", items));
+				format("%s.allMatch(Predicate<T>)", items));
 		}
 	}
 

--- a/src/test/java/com/tsyba/core/collections/CollectionTests.java
+++ b/src/test/java/com/tsyba/core/collections/CollectionTests.java
@@ -716,7 +716,7 @@ class ArrayCollection<T> implements Collection<T> {
 	}
 
 	@Override
-	public Collection<T> filter(Predicate<T> condition) {
+	public Collection<T> matchAll(Predicate<T> condition) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -765,7 +765,7 @@ class PredicateCollection<T> implements Collection<Predicate<T>> {
 	}
 
 	@Override
-	public Collection<Predicate<T>> filter(Predicate<Predicate<T>> condition) {
+	public Collection<Predicate<T>> matchAll(Predicate<Predicate<T>> condition) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
+++ b/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
@@ -251,7 +251,7 @@ class IndexRangeTests {
 
 	@DisplayName(".get(Integer)")
 	@Nested
-	class GetTests {
+	class GetAtTests {
 		@DisplayName("when range is not empty")
 		@Tests({
 			"when index is before valid index range start, fails;" +
@@ -434,7 +434,7 @@ class IndexRangeTests {
 
 	@DisplayName(".get(IndexRange)")
 	@Nested
-	class TestGetIndexRange {
+	class GetAtIndexRangeTests {
 		@DisplayName("when range is not empty")
 		@Tests({
 			"when argument range starts at valid index range start and ends within valid index range, returns range;" +
@@ -487,6 +487,25 @@ class IndexRangeTests {
 						format("%s.get(%s)", range1, range2));
 				}
 			}
+		}
+	}
+
+	@DisplayName(".filter(Predicate<Integer>)")
+	@Nested
+	class FilterTests {
+		@DisplayName("")
+		@Tests({
+			"when range is not empty, returns matching indexes;" +
+				"[1, 9);" +
+				"[2, 4, 6, 8]",
+			"when range is empty, returns empty sequence;" +
+				"[0, 0);" +
+				"[]"
+		})
+		void test(@TestRange IndexRange range, @IntList List<Integer> expected) {
+			final var matches = range.matchAll((index) -> index % 2 == 0);
+			assertEquals(expected, matches,
+				format("%s.filter(<is even>)", range));
 		}
 	}
 
@@ -638,25 +657,6 @@ class IndexRangeTests {
 			final var distinct = range.getDistinct();
 			assertSame(range, distinct,
 				format("%s.getDistinct()", range));
-		}
-	}
-
-	@DisplayName(".filter(Predicate<Integer>)")
-	@Nested
-	class FilterTests {
-		@DisplayName("")
-		@Tests({
-			"when range is not empty, returns matching indexes;" +
-				"[1, 9);" +
-				"[2, 4, 6, 8]",
-			"when range is empty, returns empty sequence;" +
-				"[0, 0);" +
-				"[]"
-		})
-		void test(@TestRange IndexRange range, @IntList List<Integer> expected) {
-			final var matches = range.filter((index) -> index % 2 == 0);
-			assertEquals(expected, matches,
-				format("%s.filter(<is even>)", range));
 		}
 	}
 

--- a/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
+++ b/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
@@ -491,10 +491,10 @@ class IndexRangeTests {
 		}
 	}
 
-	@DisplayName(".filter(Predicate<Integer>)")
+	@DisplayName(".matchAll(Predicate<Integer>)")
 	@Nested
-	class FilterTests {
-		@DisplayName("")
+	class MatchAllTests {
+		@DisplayName("\uD83D\uDC3F")
 		@Tests({
 			"when range is not empty, returns matching indexes;" +
 				"[1, 9);" +
@@ -506,7 +506,7 @@ class IndexRangeTests {
 		void test(@IntRange IndexRange range, @IntList List<Integer> expected) {
 			final var matches = range.matchAll((index) -> index % 2 == 0);
 			assertEquals(expected, matches,
-				format("%s.filter(<is even>)", range));
+				format("%s.matchAll(<is even>)", range));
 		}
 	}
 
@@ -544,7 +544,7 @@ class IndexRangeTests {
 		}
 	}
 
-	@DisplayName(".find(Integer)")
+	@DisplayName(".findAll(Integer)")
 	@Nested
 	class FindTests {
 		@DisplayName("when range is not empty")
@@ -594,13 +594,13 @@ class IndexRangeTests {
 		}
 
 		void test(IndexRange range, Integer index, List<Integer> expected) {
-			final var indexes = range.find(index);
+			final var indexes = range.findAll(index);
 			assertEquals(expected, indexes,
-				format("%s.find(%d)", range, index));
+				format("%s.findAll(%d)", range, index));
 		}
 	}
 
-	@DisplayName(".find(Sequence<T>)")
+	@DisplayName(".findAll(Sequence<T>)")
 	@Nested
 	class FindSequenceTests {
 		@DisplayName("when range is not empty")
@@ -640,9 +640,9 @@ class IndexRangeTests {
 		private void test(IndexRange range, Sequence<Integer> items,
 			Sequence<Integer> expected) {
 
-			final var indexes = range.find(items);
+			final var indexes = range.findAll(items);
 			assertEquals(expected, indexes,
-				format("%s.find(%s)", range, items));
+				format("%s.findAll(%s)", range, items));
 		}
 	}
 

--- a/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
+++ b/src/test/java/com/tsyba/core/collections/IndexRangeTests.java
@@ -1,5 +1,6 @@
 package com.tsyba.core.collections;
 
+import com.tsyba.core.collections.converter.IntOptional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
@@ -35,7 +36,7 @@ class IndexRangeTests {
 				"-4; 4;" +
 				"null"
 		})
-		void test(int start, int end, @TestRange IndexRange expected) {
+		void test(int start, int end, @IntRange IndexRange expected) {
 			try {
 				final var range = new IndexRange(start, end);
 				assertEquals(expected, range,
@@ -56,7 +57,7 @@ class IndexRangeTests {
 			"creates empty index range;" +
 				"[0, 0)"
 		})
-		void test(@TestRange IndexRange expected) {
+		void test(@IntRange IndexRange expected) {
 			final var range = new IndexRange();
 			assertEquals(expected, range,
 				"new IndexRange()");
@@ -75,7 +76,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"0"
 		})
-		void test(@TestRange IndexRange range, int expected) {
+		void test(@IntRange IndexRange range, int expected) {
 			final var count = range.getCount();
 			assertEquals(expected, count,
 				format("%s.isEmpty()", range));
@@ -94,7 +95,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"[0, 0)"
 		})
-		void test(@TestRange IndexRange range, @TestRange IndexRange expected) {
+		void test(@IntRange IndexRange range, @IntRange IndexRange expected) {
 			final var returned = range.getIndexRange();
 			assertEquals(expected, returned,
 				format("%s.getIndexRange()", range));
@@ -125,7 +126,7 @@ class IndexRangeTests {
 				"[4, 8); null;" +
 				"false"
 		})
-		void testNotEmpty(@TestRange IndexRange range, Integer index, boolean expected) {
+		void testNotEmpty(@IntRange IndexRange range, Integer index, boolean expected) {
 			test(range, index, expected);
 		}
 
@@ -144,7 +145,7 @@ class IndexRangeTests {
 				"[0, 0); null;" +
 				"false"
 		})
-		void testEmpty(@TestRange IndexRange range, Integer index, boolean expected) {
+		void testEmpty(@IntRange IndexRange range, Integer index, boolean expected) {
 			test(range, index, expected);
 		}
 
@@ -182,7 +183,7 @@ class IndexRangeTests {
 				"[6, 9); [0, 0);" +
 				"true"
 		})
-		void testNotEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
+		void testNotEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
 			boolean expected) {
 			test(range1, range2, expected);
 		}
@@ -196,7 +197,7 @@ class IndexRangeTests {
 				"[0, 0); [0, 0);" +
 				"true"
 		})
-		void testEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
+		void testEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
 			boolean expected) {
 			test(range1, range2, expected);
 		}
@@ -221,7 +222,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"null"
 		})
-		void test(@TestRange IndexRange range, @IntOptional Optional<Integer> expected) {
+		void test(@IntRange IndexRange range, @IntOptional Optional<Integer> expected) {
 			final var first = range.getFirst();
 			assertEquals(expected, first,
 				format("%s.getFirst()", range));
@@ -241,7 +242,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"null"
 		})
-		void test(@TestRange IndexRange range, @IntOptional Optional<Integer> expected) {
+		void test(@IntRange IndexRange range, @IntOptional Optional<Integer> expected) {
 			final var first = range.getLast();
 			assertEquals(expected, first,
 				format("%s.getLast()", range));
@@ -270,7 +271,7 @@ class IndexRangeTests {
 				"[4, 8); 9;" +
 				"null; 9 ∉ [0, 4)"
 		})
-		void testNotEmpty(@TestRange IndexRange range, int index, Integer expected1,
+		void testNotEmpty(@IntRange IndexRange range, int index, Integer expected1,
 			@IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
@@ -287,7 +288,7 @@ class IndexRangeTests {
 				"[0, 0); 1;" +
 				"null; 1 ∉ [0, 0)",
 		})
-		void testEmpty(@TestRange IndexRange range, int index, Integer expected1,
+		void testEmpty(@IntRange IndexRange range, int index, Integer expected1,
 			@IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
@@ -331,8 +332,8 @@ class IndexRangeTests {
 				"[2, 9); 12;" +
 				"null; 12 ∉ [0, 7)",
 		})
-		void testNotEmpty(@TestRange IndexRange range, int index,
-			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testNotEmpty(@IntRange IndexRange range, int index,
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
 
@@ -348,8 +349,8 @@ class IndexRangeTests {
 				"[0, 0); 1;" +
 				"null; 1 ∉ [0, 0)",
 		})
-		void testEmpty(@TestRange IndexRange range, int index,
-			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testEmpty(@IntRange IndexRange range, int index,
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
 
@@ -392,8 +393,8 @@ class IndexRangeTests {
 				"[2, 9); 12;" +
 				"null; 12 ∉ [0, 7)",
 		})
-		void testNotEmpty(@TestRange IndexRange range, int index,
-			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testNotEmpty(@IntRange IndexRange range, int index,
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
 
@@ -409,8 +410,8 @@ class IndexRangeTests {
 				"[0, 0); 1;" +
 				"null; 1 ∉ [0, 0)",
 		})
-		void testEmpty(@TestRange IndexRange range, int index,
-			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testEmpty(@IntRange IndexRange range, int index,
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
 		}
 
@@ -453,8 +454,8 @@ class IndexRangeTests {
 				"[6, 9); [0, 0);" +
 				"[0, 0); null"
 		})
-		void testNotEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
-			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testNotEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range1, range2, expected1, expected2);
 		}
 
@@ -467,8 +468,8 @@ class IndexRangeTests {
 				"[0, 0); [0, 0);" +
 				"[0, 0); null"
 		})
-		void testEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
-			@TestRange IndexRange expected1, @IndexRangeException Exception expected2) {
+		void testEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
+			@IntRange IndexRange expected1, @IndexRangeException Exception expected2) {
 			test(range1, range2, expected1, expected2);
 		}
 
@@ -502,7 +503,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"[]"
 		})
-		void test(@TestRange IndexRange range, @IntList List<Integer> expected) {
+		void test(@IntRange IndexRange range, @IntList List<Integer> expected) {
 			final var matches = range.matchAll((index) -> index % 2 == 0);
 			assertEquals(expected, matches,
 				format("%s.filter(<is even>)", range));
@@ -534,7 +535,7 @@ class IndexRangeTests {
 				"[0, 0); 0;" +
 				"null"
 		})
-		void test(@TestRange IndexRange range, int item,
+		void test(@IntRange IndexRange range, int item,
 			@IntOptional Optional<Integer> expected) {
 
 			final var index = range.findFirst(item);
@@ -567,7 +568,7 @@ class IndexRangeTests {
 				"[4, 9); null;" +
 				"[]"
 		})
-		void testNotEmpty(@TestRange IndexRange range, Integer index,
+		void testNotEmpty(@IntRange IndexRange range, Integer index,
 			@IntList List<Integer> expected) {
 			test(range, index, expected);
 		}
@@ -587,7 +588,7 @@ class IndexRangeTests {
 				"[0, 0); null;" +
 				"[]"
 		})
-		void testEmpty(@TestRange IndexRange range, Integer index,
+		void testEmpty(@IntRange IndexRange range, Integer index,
 			@IntList List<Integer> expected) {
 			test(range, index, expected);
 		}
@@ -617,7 +618,7 @@ class IndexRangeTests {
 				"[3, 9); [];" +
 				"[0, 1, 2, 3, 4, 5]"
 		})
-		void testNotEmpty(@TestRange IndexRange range, @IntList List<Integer> items,
+		void testNotEmpty(@IntRange IndexRange range, @IntList List<Integer> items,
 			@IntList List<Integer> expected) {
 			test(range, items, expected);
 		}
@@ -631,7 +632,7 @@ class IndexRangeTests {
 				"[0, 0); [];" +
 				"[]"
 		})
-		void testEmpty(@TestRange IndexRange range, @IntList List<Integer> items,
+		void testEmpty(@IntRange IndexRange range, @IntList List<Integer> items,
 			@IntList List<Integer> expected) {
 			test(range, items, expected);
 		}
@@ -653,7 +654,7 @@ class IndexRangeTests {
 			"returns itself;" +
 				"[4, 9)"
 		})
-		void test(@TestRange IndexRange range) {
+		void test(@IntRange IndexRange range) {
 			final var distinct = range.getDistinct();
 			assertSame(range, distinct,
 				format("%s.getDistinct()", range));
@@ -678,7 +679,7 @@ class IndexRangeTests {
 				"[4, 8); null;" +
 				"false"
 		})
-		void testNotEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
+		void testNotEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
 			boolean expected) {
 			test(range1, range2, expected);
 		}
@@ -695,7 +696,7 @@ class IndexRangeTests {
 				"[0, 0); null;" +
 				"false"
 		})
-		void testEmpty(@TestRange IndexRange range1, @TestRange IndexRange range2,
+		void testEmpty(@IntRange IndexRange range1, @IntRange IndexRange range2,
 			boolean expected) {
 			test(range1, range2, expected);
 		}
@@ -728,7 +729,7 @@ class IndexRangeTests {
 				"[2, 6); 9;" +
 				"null; 9 ∉ [0, 4)"
 		})
-		void testNotEmpty(@TestRange IndexRange range, int index,
+		void testNotEmpty(@IntRange IndexRange range, int index,
 			@StringList List<String> expected1,
 			@IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
@@ -746,7 +747,7 @@ class IndexRangeTests {
 				"[0, 0); 1;" +
 				"null; 1 ∉ [0, 0)"
 		})
-		void testEmpty(@TestRange IndexRange range, int index,
+		void testEmpty(@IntRange IndexRange range, int index,
 			@StringList List<String> expected1,
 			@IndexRangeException Exception expected2) {
 			test(range, index, expected1, expected2);
@@ -788,7 +789,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"[]"
 		})
-		void test(@TestRange IndexRange range, @StringList List<String> expected) {
+		void test(@IntRange IndexRange range, @StringList List<String> expected) {
 			final var iterator = range.iterator();
 			final var iterated = new MutableList<String>();
 			while (iterator.hasNext()) {
@@ -813,7 +814,7 @@ class IndexRangeTests {
 				"[0, 0);" +
 				"[0, 0)"
 		})
-		void test(@TestRange IndexRange range, String expected) {
+		void test(@IntRange IndexRange range, String expected) {
 			final var string = range.toString();
 			assertEquals(expected, string,
 				format("%s.toString()", range));
@@ -822,8 +823,8 @@ class IndexRangeTests {
 }
 
 @Retention(RetentionPolicy.RUNTIME)
-@ConvertWith(TestRange.Converter.class)
-@interface TestRange {
+@ConvertWith(IntRange.Converter.class)
+@interface IntRange {
 	class Converter extends TypedArgumentConverter<String, IndexRange> {
 		protected Converter() {
 			super(String.class, IndexRange.class);
@@ -846,9 +847,9 @@ class IndexRangeTests {
 	}
 }
 
-@ConvertWith(TestRangeOptional.Converter.class)
+@ConvertWith(IntRangeOptional.Converter.class)
 @Retention(RetentionPolicy.RUNTIME)
-@interface TestRangeOptional {
+@interface IntRangeOptional {
 	@SuppressWarnings("rawtypes")
 	class Converter extends TypedArgumentConverter<String, Optional> {
 		protected Converter() {
@@ -857,7 +858,7 @@ class IndexRangeTests {
 
 		@Override
 		protected Optional<IndexRange> convert(String s) throws ArgumentConversionException {
-			final var converter = new TestRange.Converter();
+			final var converter = new IntRange.Converter();
 			return Optional.ofNullable(s)
 				.map(converter::convert);
 		}

--- a/src/test/java/com/tsyba/core/collections/ListTests.java
+++ b/src/test/java/com/tsyba/core/collections/ListTests.java
@@ -336,6 +336,35 @@ public class ListTests {
 		}
 	}
 
+	@DisplayName(".filter(Predicate<T>)")
+	@Nested
+	class FilterTests {
+		@DisplayName("\uD83D\uDD31")
+		@Tests({
+			"when some items match, returns matched items;" +
+				"[g, R, W, s, A, s, W];" +
+				"[R, W, A, W]",
+			"when all items match, returns matched items;" +
+				"[R, W, A, X, K, S];" +
+				"[R, W, A, X, K, S]",
+			"when no items match, returns empty list;" +
+				"[g, m, k, o, l, m];" +
+				"[]",
+			"when list is empty, returns empty list;" +
+				"[];" +
+				"[]"
+		})
+		void test(@StringList List<String> items, @StringList List<String> expected) {
+			final var matched = items.matchAll((item) -> {
+				return item.toUpperCase()
+					.equals(item);
+			});
+
+			assertEquals(expected, matched,
+				format("%s.filter(<is uppercase>)", items));
+		}
+	}
+
 	@DisplayName(".find(T)")
 	@Nested
 	class FindTests {
@@ -467,35 +496,6 @@ public class ListTests {
 			final var reversed = items.reverse();
 			assertEquals(expected, reversed,
 				format("%s.reverse()", items));
-		}
-	}
-
-	@DisplayName(".filter(Predicate<T>)")
-	@Nested
-	class FilterTests {
-		@DisplayName("\uD83D\uDD31")
-		@Tests({
-			"when some items match, returns matched items;" +
-				"[g, R, W, s, A, s, W];" +
-				"[R, W, A, W]",
-			"when all items match, returns matched items;" +
-				"[R, W, A, X, K, S];" +
-				"[R, W, A, X, K, S]",
-			"when no items match, returns empty list;" +
-				"[g, m, k, o, l, m];" +
-				"[]",
-			"when list is empty, returns empty list;" +
-				"[];" +
-				"[]"
-		})
-		void test(@StringList List<String> items, @StringList List<String> expected) {
-			final var matched = items.filter((item) -> {
-				return item.toUpperCase()
-					.equals(item);
-			});
-
-			assertEquals(expected, matched,
-				format("%s.filter(<is uppercase>)", items));
 		}
 	}
 

--- a/src/test/java/com/tsyba/core/collections/ListTests.java
+++ b/src/test/java/com/tsyba/core/collections/ListTests.java
@@ -337,9 +337,9 @@ public class ListTests {
 		}
 	}
 
-	@DisplayName(".filter(Predicate<T>)")
+	@DisplayName(".matchAll(Predicate<T>)")
 	@Nested
-	class FilterTests {
+	class MatchAllTests {
 		@DisplayName("\uD83D\uDD31")
 		@Tests({
 			"when some items match, returns matched items;" +
@@ -362,11 +362,11 @@ public class ListTests {
 			});
 
 			assertEquals(expected, matched,
-				format("%s.filter(<is uppercase>)", items));
+				format("%s.matchAll(<is uppercase>)", items));
 		}
 	}
 
-	@DisplayName(".find(T)")
+	@DisplayName(".findAll(T)")
 	@Nested
 	class FindTests {
 		@DisplayName("when list is not empty")
@@ -404,13 +404,13 @@ public class ListTests {
 		}
 
 		private void test(List<String> items, String item, List<Integer> expected) {
-			final var indexes = items.find(item);
+			final var indexes = items.findAll(item);
 			assertEquals(expected, indexes,
-				format("%s.find(%s)", items, item));
+				format("%s.findAll(%s)", items, item));
 		}
 	}
 
-	@DisplayName(".find(Sequence<T>)")
+	@DisplayName(".findAll(Sequence<T>)")
 	@Nested
 	class FindSequenceTests {
 		@DisplayName("when list is not empty")
@@ -453,9 +453,9 @@ public class ListTests {
 		private void test(List<String> items1, List<String> items2,
 			List<Integer> expected) {
 
-			final var indexes = items1.find(items2);
+			final var indexes = items1.findAll(items2);
 			assertEquals(expected, indexes,
-				format("%s.find(%s)", items1, items2));
+				format("%s.findAll(%s)", items1, items2));
 		}
 	}
 

--- a/src/test/java/com/tsyba/core/collections/ListTests.java
+++ b/src/test/java/com/tsyba/core/collections/ListTests.java
@@ -1,5 +1,6 @@
 package com.tsyba.core.collections;
 
+import com.tsyba.core.collections.converter.StringArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
@@ -298,7 +299,7 @@ public class ListTests {
 				"[f, y, R, e, l, k, g, S]; [0, 0);" +
 				"[]"
 		})
-		void testNotEmpty(@StringList List<String> items, @TestRange IndexRange range,
+		void testNotEmpty(@StringList List<String> items, @IntRange IndexRange range,
 			@StringList List<String> expected) {
 			test(items, range, expected);
 		}
@@ -312,7 +313,7 @@ public class ListTests {
 				"[]; [0, 0);" +
 				"[]"
 		})
-		void testEmpty(@StringList List<String> items, @TestRange IndexRange range,
+		void testEmpty(@StringList List<String> items, @IntRange IndexRange range,
 			@StringList List<String> expected) {
 			test(items, range, expected);
 		}

--- a/src/test/java/com/tsyba/core/collections/MapTests.java
+++ b/src/test/java/com/tsyba/core/collections/MapTests.java
@@ -1,5 +1,7 @@
 package com.tsyba.core.collections;
 
+import com.tsyba.core.collections.converter.StringArray;
+import com.tsyba.core.collections.converter.StringOptional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.converter.ArgumentConversionException;

--- a/src/test/java/com/tsyba/core/collections/MutableMapTests.java
+++ b/src/test/java/com/tsyba/core/collections/MutableMapTests.java
@@ -1,6 +1,7 @@
 package com.tsyba.core.collections;
 
 
+import com.tsyba.core.collections.converter.StringArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.converter.ArgumentConversionException;

--- a/src/test/java/com/tsyba/core/collections/MutableSetTests.java
+++ b/src/test/java/com/tsyba/core/collections/MutableSetTests.java
@@ -20,7 +20,7 @@ public class MutableSetTests {
 	@DisplayName(".getDistinct()")
 	@Nested
 	class GetDistinctTests {
-		@DisplayName("")
+		@DisplayName("\uD83D\uDC5B")
 		@Tests({
 			"returns a copy of itself;" +
 				"[g, t, w, s, A, q]"

--- a/src/test/java/com/tsyba/core/collections/MutableSetTests.java
+++ b/src/test/java/com/tsyba/core/collections/MutableSetTests.java
@@ -417,6 +417,18 @@ public class MutableSetTests {
 		assertEquals(expected, items);
 	}
 
+	@DisplayName(".matchAll(Predicate<T>)")
+	@ParameterizedTest(name = "{0}")
+	@CsvSource(value = {
+		"returns a mutable set;" +
+			"[f, r, q, e, a]"
+	}, delimiter = ';')
+	void testFilter(String name, @StringMutableSet MutableSet<String> items) {
+		final var returned = items.matchAll(String::isBlank);
+		final var klass = returned.getClass();
+		assertEquals(MutableSet.class, klass);
+	}
+
 	@DisplayName(".iterate(Consumer<T>)")
 	@ParameterizedTest(name = "{0}")
 	@CsvSource(value = {
@@ -427,18 +439,6 @@ public class MutableSetTests {
 		@SuppressWarnings("ResultOfMethodCallIgnored")
 		final var returned = items.iterate(String::toLowerCase);
 		assertSame(items, returned);
-	}
-
-	@DisplayName(".filter(Predicate<T>)")
-	@ParameterizedTest(name = "{0}")
-	@CsvSource(value = {
-		"returns a mutable set;" +
-			"[f, r, q, e, a]"
-	}, delimiter = ';')
-	void testFilter(String name, @StringMutableSet MutableSet<String> items) {
-		final var returned = items.filter(String::isBlank);
-		final var klass = returned.getClass();
-		assertEquals(MutableSet.class, klass);
 	}
 
 	@DisplayName(".convert(Function<T, R>)")

--- a/src/test/java/com/tsyba/core/collections/MutableSetTests.java
+++ b/src/test/java/com/tsyba/core/collections/MutableSetTests.java
@@ -1,5 +1,6 @@
 package com.tsyba.core.collections;
 
+import com.tsyba.core.collections.converter.StringArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/tsyba/core/collections/SequenceTests.java
+++ b/src/test/java/com/tsyba/core/collections/SequenceTests.java
@@ -414,47 +414,47 @@ public class SequenceTests {
 			return new Sequence<>() {
 				@Override
 				public Sequence<String> getPrefix(int index) {
-					return null;
+					throw new UnsupportedOperationException();
 				}
 
 				@Override
 				public Sequence<String> getSuffix(int index) {
-					return null;
+					throw new UnsupportedOperationException();
 				}
 
 				@Override
 				public Sequence<String> get(IndexRange range) {
-					return null;
+					throw new UnsupportedOperationException();
 				}
 
 				@Override
 				public Sequence<String> matchAll(Predicate<String> condition) {
-					return null;
+					throw new UnsupportedOperationException();
 				}
 
 				@Override
-				public Sequence<Integer> find(String item) {
-					return null;
+				public Sequence<Integer> findAll(String item) {
+					throw new UnsupportedOperationException();
 				}
 
 				@Override
-				public Sequence<Integer> find(Sequence<String> items) {
-					return null;
+				public Sequence<Integer> findAll(Sequence<String> items) {
+					throw new UnsupportedOperationException();
 				}
 
 				@Override
 				public Collection<String> getDistinct() {
-					return null;
+					throw new UnsupportedOperationException();
 				}
 
 				@Override
 				public Sequence<String> reverse() {
-					return null;
+					throw new UnsupportedOperationException();
 				}
 
 				@Override
 				public <R> Sequence<R> convert(Function<String, R> converter) {
-					return null;
+					throw new UnsupportedOperationException();
 				}
 
 				@Override

--- a/src/test/java/com/tsyba/core/collections/SequenceTests.java
+++ b/src/test/java/com/tsyba/core/collections/SequenceTests.java
@@ -425,6 +425,11 @@ public class SequenceTests {
 				}
 
 				@Override
+				public Sequence<String> matchAll(Predicate<String> condition) {
+					return null;
+				}
+
+				@Override
 				public Sequence<Integer> find(String item) {
 					return null;
 				}
@@ -441,11 +446,6 @@ public class SequenceTests {
 
 				@Override
 				public Sequence<String> reverse() {
-					return null;
-				}
-
-				@Override
-				public Sequence<String> filter(Predicate<String> condition) {
 					return null;
 				}
 

--- a/src/test/java/com/tsyba/core/collections/SequenceTests.java
+++ b/src/test/java/com/tsyba/core/collections/SequenceTests.java
@@ -1,5 +1,8 @@
 package com.tsyba.core.collections;
 
+import com.tsyba.core.collections.converter.IntOptional;
+import com.tsyba.core.collections.converter.StringArray;
+import com.tsyba.core.collections.converter.StringOptional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.converter.ArgumentConversionException;
@@ -30,8 +33,8 @@ public class SequenceTests {
 				"[];" +
 				"[0, 0)"
 		})
-		void test(@TestSequence Sequence<String> items,
-			@TestRange IndexRange expected) {
+		void test(@StringSequence Sequence<String> items,
+			@IntRange IndexRange expected) {
 
 			final var range = items.getIndexRange();
 			assertEquals(expected, range,
@@ -52,7 +55,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@TestSequence Sequence<String> items,
+		void test(@StringSequence Sequence<String> items,
 			@StringOptional Optional<String> expected) {
 
 			final var item = items.getFirst();
@@ -74,7 +77,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@TestSequence Sequence<String> items,
+		void test(@StringSequence Sequence<String> items,
 			@StringOptional Optional<String> expected) {
 
 			final var item = items.getLast();
@@ -98,7 +101,7 @@ public class SequenceTests {
 				"[g, B, s, E, q, s, K]; 12;" +
 				"null; 12 ∉ [0, 7)"
 		})
-		void testNotEmpty(@TestSequence Sequence<String> items, int index,
+		void testNotEmpty(@StringSequence Sequence<String> items, int index,
 			String expected1, @IndexRangeException Exception expected2) {
 			test(items, index, expected1, expected2);
 		}
@@ -112,7 +115,7 @@ public class SequenceTests {
 				"[]; 0;" +
 				"null; 0 ∉ [0, 0)"
 		})
-		void testEmpty(@TestSequence Sequence<String> items, int index,
+		void testEmpty(@StringSequence Sequence<String> items, int index,
 			String expected1, @IndexRangeException Exception expected2) {
 			test(items, index, expected1, expected2);
 		}
@@ -151,7 +154,7 @@ public class SequenceTests {
 				"[g, T, s, l, I, o]; 13;" +
 				"null",
 		})
-		void testNotEmpty(@TestSequence Sequence<String> items, int index,
+		void testNotEmpty(@StringSequence Sequence<String> items, int index,
 			@IntOptional Optional<Integer> expected) {
 			test(items, index, expected);
 		}
@@ -165,7 +168,7 @@ public class SequenceTests {
 				"[]; 0;" +
 				"null",
 		})
-		void testEmpty(@TestSequence Sequence<String> items, int index,
+		void testEmpty(@StringSequence Sequence<String> items, int index,
 			@IntOptional Optional<Integer> expected) {
 			test(items, index, expected);
 		}
@@ -195,9 +198,9 @@ public class SequenceTests {
 				"[g, I, m, k, L, s, D, n]; [3, 15);" +
 				"null"
 		})
-		void testNotEmpty(@TestSequence Sequence<String> items,
-			@TestRange IndexRange range,
-			@TestRangeOptional Optional<IndexRange> expected) {
+		void testNotEmpty(@StringSequence Sequence<String> items,
+			@IntRange IndexRange range,
+			@IntRangeOptional Optional<IndexRange> expected) {
 			test(items, range, expected);
 		}
 
@@ -207,9 +210,9 @@ public class SequenceTests {
 				"[]; [0, 2);" +
 				"null"
 		})
-		void testEmpty(@TestSequence Sequence<String> items,
-			@TestRange IndexRange range,
-			@TestRangeOptional Optional<IndexRange> expected) {
+		void testEmpty(@StringSequence Sequence<String> items,
+			@IntRange IndexRange range,
+			@IntRangeOptional Optional<IndexRange> expected) {
 			test(items, range, expected);
 		}
 
@@ -241,7 +244,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@TestSequence Sequence<String> items,
+		void test(@StringSequence Sequence<String> items,
 			@StringOptional Optional<String> expected) {
 
 			final var matched = items.matchFirst((item) -> {
@@ -273,7 +276,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@TestSequence Sequence<String> items, String item,
+		void test(@StringSequence Sequence<String> items, String item,
 			@IntOptional Optional<Integer> expected) {
 
 			final var index = items.findFirst(item);
@@ -301,7 +304,7 @@ public class SequenceTests {
 				"null"
 		})
 		@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-		void test(@TestSequence Sequence<String> items,
+		void test(@StringSequence Sequence<String> items,
 			@IntOptional Optional<Integer> expected) {
 
 			final var index = items.findFirst((item) ->
@@ -335,8 +338,8 @@ public class SequenceTests {
 				"[u, Y, k, L, m, n, F, s, d]; [];" +
 				"0"
 		})
-		void testNotEmpty(@TestSequence Sequence<String> items1,
-			@TestSequence Sequence<String> items2,
+		void testNotEmpty(@StringSequence Sequence<String> items1,
+			@StringSequence Sequence<String> items2,
 			@IntOptional Optional<Integer> expected) {
 			test(items1, items2, expected);
 		}
@@ -350,8 +353,8 @@ public class SequenceTests {
 				"[]; [];" +
 				"null"
 		})
-		void testEmpty(@TestSequence Sequence<String> items1,
-			@TestSequence Sequence<String> items2,
+		void testEmpty(@StringSequence Sequence<String> items1,
+			@StringSequence Sequence<String> items2,
 			@IntOptional Optional<Integer> expected) {
 			test(items1, items2, expected);
 		}
@@ -377,7 +380,7 @@ public class SequenceTests {
 				"[];" +
 				"[]"
 		})
-		void test(@TestSequence Sequence<String> items,
+		void test(@StringSequence Sequence<String> items,
 			@StringMap Map<String, String> expected) {
 
 			final var enumerated = new MutableMap<Integer, String>();
@@ -395,8 +398,8 @@ public class SequenceTests {
 }
 
 @Retention(RetentionPolicy.RUNTIME)
-@ConvertWith(TestSequence.Converter.class)
-@interface TestSequence {
+@ConvertWith(StringSequence.Converter.class)
+@interface StringSequence {
 	@SuppressWarnings("rawtypes")
 	class Converter extends TypedArgumentConverter<String, Sequence> {
 		protected Converter() {
@@ -456,41 +459,9 @@ public class SequenceTests {
 
 				@Override
 				public Iterator<String> iterator() {
-					return new Iterator<>() {
-						private int index = 0;
-
-						@Override
-						public boolean hasNext() {
-							return index < items.length;
-						}
-
-						@Override
-						public String next() {
-							final var item = items[index];
-							++index;
-
-							return item;
-						}
-					};
+					return new ArrayIterator<>(items);
 				}
 			};
-		}
-	}
-}
-
-@ConvertWith(IntOptional.Converter.class)
-@Retention(RetentionPolicy.RUNTIME)
-@interface IntOptional {
-	@SuppressWarnings("rawtypes")
-	class Converter extends TypedArgumentConverter<String, Optional> {
-		protected Converter() {
-			super(String.class, Optional.class);
-		}
-
-		@Override
-		protected Optional<Integer> convert(String s) throws ArgumentConversionException {
-			return Optional.ofNullable(s)
-				.map(Integer::parseInt);
 		}
 	}
 }

--- a/src/test/java/com/tsyba/core/collections/SetTests.java
+++ b/src/test/java/com/tsyba/core/collections/SetTests.java
@@ -341,7 +341,7 @@ public class SetTests {
 		assertEquals(expected, product);
 	}
 
-	@DisplayName(".filter(Predicate<T>)")
+	@DisplayName(".matchAll(Predicate<T>)")
 	@ParameterizedTest(name = "{0}")
 	@CsvSource(value = {
 		"when some items match, returns matched items;" +
@@ -357,7 +357,7 @@ public class SetTests {
 	void testFilter(String name, @StringSet Set<String> items,
 		@StringSet Set<String> expected) {
 
-		final var filtered = items.filter((item) -> {
+		final var filtered = items.matchAll((item) -> {
 			return item.toLowerCase()
 				.equals(item);
 		});

--- a/src/test/java/com/tsyba/core/collections/SetTests.java
+++ b/src/test/java/com/tsyba/core/collections/SetTests.java
@@ -1,5 +1,6 @@
 package com.tsyba.core.collections;
 
+import com.tsyba.core.collections.converter.StringArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/tsyba/core/collections/converter/IntOptional.java
+++ b/src/test/java/com/tsyba/core/collections/converter/IntOptional.java
@@ -1,0 +1,26 @@
+package com.tsyba.core.collections.converter;
+
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.converter.TypedArgumentConverter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Optional;
+
+@ConvertWith(IntOptional.Converter.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface IntOptional {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, Optional> {
+		protected Converter() {
+			super(String.class, Optional.class);
+		}
+
+		@Override
+		protected Optional<Integer> convert(String s) throws ArgumentConversionException {
+			return Optional.ofNullable(s)
+				.map(Integer::parseInt);
+		}
+	}
+}

--- a/src/test/java/com/tsyba/core/collections/converter/StringArray.java
+++ b/src/test/java/com/tsyba/core/collections/converter/StringArray.java
@@ -1,0 +1,40 @@
+package com.tsyba.core.collections.converter;
+
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.converter.TypedArgumentConverter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Arrays;
+
+@Retention(RetentionPolicy.RUNTIME)
+@ConvertWith(StringArray.Converter.class)
+public @interface StringArray {
+	class Converter extends TypedArgumentConverter<String, String[]> {
+		public Converter() {
+			super(String.class, String[].class);
+		}
+
+		@Override
+		public String[] convert(String s) throws ArgumentConversionException {
+			if (s == null) {
+				return null;
+			}
+
+			final var substring = s.substring(
+				s.indexOf("[") + 1,
+				s.lastIndexOf("]"));
+
+			if (substring.isBlank()) {
+				return new String[0];
+			} else {
+				final var string = substring.split("\\s*,\\s*");
+
+				return Arrays.stream(string)
+					.filter((item) -> !item.equals("null"))
+					.toArray(String[]::new);
+			}
+		}
+	}
+}

--- a/src/test/java/com/tsyba/core/collections/converter/StringOptional.java
+++ b/src/test/java/com/tsyba/core/collections/converter/StringOptional.java
@@ -1,0 +1,25 @@
+package com.tsyba.core.collections.converter;
+
+import org.junit.jupiter.params.converter.ArgumentConversionException;
+import org.junit.jupiter.params.converter.ConvertWith;
+import org.junit.jupiter.params.converter.TypedArgumentConverter;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.Optional;
+
+@ConvertWith(StringOptional.Converter.class)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StringOptional {
+	@SuppressWarnings("rawtypes")
+	class Converter extends TypedArgumentConverter<String, Optional> {
+		protected Converter() {
+			super(String.class, Optional.class);
+		}
+
+		@Override
+		protected Optional<String> convert(String s) throws ArgumentConversionException {
+			return Optional.ofNullable(s);
+		}
+	}
+}


### PR DESCRIPTION
This update renames methods

- `Collection.filter` to `.matchAll`
- `Sequence.find` to `.findAll`